### PR TITLE
Move core DynamoDB code to the base package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,12 +21,14 @@ repositories {
 }
 
 dependencies {
+    compile 'org.apache.commons:commons-lang3:' + commonsLang3Ver
     compile 'com.google.guava:guava:' + guavaVer
     compile 'joda-time:joda-time:' + jodaVer
     compile 'commons-codec:commons-codec:' + commonsCodecVer
     compile 'org.apache.shiro:shiro-core:' + shiroVer
     compile 'org.bouncycastle:bcprov-jdk15on:' + bcVer
     compile 'org.bouncycastle:bcpkix-jdk15on:' + bcVer
+    compile 'com.amazonaws:aws-java-sdk-dynamodb:' + awsVer
     testCompile 'junit:junit:' + junitVer
     testRuntime 'ch.qos.logback:logback-classic:' + logbackVer
     testRuntime 'ch.qos.logback:logback-core:' + logbackVer

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,9 @@ dependencies {
     compile 'org.bouncycastle:bcprov-jdk15on:' + bcVer
     compile 'org.bouncycastle:bcpkix-jdk15on:' + bcVer
     compile 'com.amazonaws:aws-java-sdk-dynamodb:' + awsVer
+    compile 'redis.clients:jedis:' + redisVer
     testCompile 'junit:junit:' + junitVer
+    testCompile 'org.mockito:mockito-core:' + mockitoVer
     testRuntime 'ch.qos.logback:logback-classic:' + logbackVer
     testRuntime 'ch.qos.logback:logback-core:' + logbackVer
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,5 +5,7 @@ jodaVer = 2.8.2
 shiroVer = 1.2.4
 bcVer = 1.52
 awsVer = 1.10.17
+redisVer = 2.7.2
 junitVer = 4.12
+mockitoVer = 1.10.19
 logbackVer = 1.1.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,9 @@
+commonsLang3Ver = 3.4
+commonsCodecVer = 1.10
 guavaVer = 18.0
 jodaVer = 2.8.2
-commonsCodecVer = 1.10
 shiroVer = 1.2.4
 bcVer = 1.52
+awsVer = 1.10.17
 junitVer = 4.12
 logbackVer = 1.1.3

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/AnnotationBasedTableCreator.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/AnnotationBasedTableCreator.java
@@ -42,7 +42,7 @@ import com.google.common.reflect.ClassPath.ClassInfo;
  * Scans a package for types that are annotated as DynamoDBTable and maps
  * them to TableDescription objects.
  */
-public class DynamoTableMapper {
+public class AnnotationBasedTableCreator {
 
     public static final long DEFAULT_READ_CAPACITY = 10;
     public static final long DEFAULT_WRITE_CAPACITY = 10;
@@ -54,7 +54,7 @@ public class DynamoTableMapper {
      * @param tablePackage  The package to scan.
      * @param config  The config whose user and environment will become part of the table name.
      */
-    public DynamoTableMapper(String tablePackage, Config config) {
+    public AnnotationBasedTableCreator(String tablePackage, Config config) {
         this.tablePackage = tablePackage;
         this.config = config;
     }

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoProjection.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoProjection.java
@@ -1,0 +1,21 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static java.lang.annotation.ElementType.METHOD;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.amazonaws.services.dynamodbv2.model.ProjectionType;
+
+/**
+ * An optional annotation for global indices, sets the projection type of
+ * the index. This annotation should go on the same method as the annotation
+ * for the index's hash key.
+ */
+@Target({METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DynamoProjection {
+    ProjectionType projectionType();
+    String globalSecondaryIndexName();
+}

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoTableMapper.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoTableMapper.java
@@ -38,6 +38,10 @@ import com.google.common.collect.Lists;
 import com.google.common.reflect.ClassPath;
 import com.google.common.reflect.ClassPath.ClassInfo;
 
+/**
+ * Scans a package for types that are annotated as DynamoDBTable and maps
+ * them to TableDescription objects.
+ */
 public class DynamoTableMapper {
 
     public static final long DEFAULT_READ_CAPACITY = 10;
@@ -46,6 +50,10 @@ public class DynamoTableMapper {
     private final String tablePackage;
     private final Config config;
 
+    /**
+     * @param tablePackage  The package to scan.
+     * @param config  The config whose user and environment will become part of the table name.
+     */
     public DynamoTableMapper(String tablePackage, Config config) {
         this.tablePackage = tablePackage;
         this.config = config;

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoTableMapper.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoTableMapper.java
@@ -1,0 +1,329 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.joda.time.LocalDate;
+import org.sagebionetworks.bridge.config.Config;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexRangeKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
+import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndexDescription;
+import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
+import com.amazonaws.services.dynamodbv2.model.KeyType;
+import com.amazonaws.services.dynamodbv2.model.LocalSecondaryIndexDescription;
+import com.amazonaws.services.dynamodbv2.model.Projection;
+import com.amazonaws.services.dynamodbv2.model.ProjectionType;
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputDescription;
+import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
+import com.amazonaws.services.dynamodbv2.model.TableDescription;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.reflect.ClassPath;
+import com.google.common.reflect.ClassPath.ClassInfo;
+
+public class DynamoTableMapper {
+
+    public static final long DEFAULT_READ_CAPACITY = 10;
+    public static final long DEFAULT_WRITE_CAPACITY = 10;
+
+    private final String tablePackage;
+    private final Config config;
+
+    public DynamoTableMapper(String tablePackage, Config config) {
+        this.tablePackage = tablePackage;
+        this.config = config;
+    }
+
+    public List<TableDescription> getTables() {
+        return getAnnotatedTables(loadDynamoTableClasses());
+    }
+
+    /**
+     * Uses reflection to get all the annotated DynamoDBTable.
+     */
+    List<Class<?>> loadDynamoTableClasses() {
+        final List<Class<?>> classes = new ArrayList<>();
+        final ClassLoader classLoader = getClass().getClassLoader();
+        try {
+            final ImmutableSet<ClassInfo> classSet = ClassPath.from(classLoader).getTopLevelClasses(tablePackage);
+            for (ClassInfo classInfo : classSet) {
+                Class<?> clazz = classInfo.load();
+                if (clazz.isAnnotationPresent(DynamoDBTable.class)) {
+                    classes.add(clazz);
+                }
+            }
+            return classes;
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private List<TableDescription> getAnnotatedTables(final List<Class<?>> classes) {
+        final Map<String, TableDescription> tables = new HashMap<>();
+        for (final Class<?> clazz : classes) {
+            final List<KeySchemaElement> keySchema = new ArrayList<>();
+            final Map<String, AttributeDefinition> attributes = new HashMap<>();
+            final List<GlobalSecondaryIndexDescription> globalIndices = new ArrayList<>();
+            final List<LocalSecondaryIndexDescription> localIndices = new ArrayList<>();
+            final ProvisionedThroughput throughput = getThroughput(clazz);
+            Method[] methods = clazz.getMethods();
+            KeySchemaElement hashKey = null;
+            for (Method method : methods) {
+                if (method.isAnnotationPresent(DynamoDBHashKey.class)) {
+                    // Hash key
+                    DynamoDBHashKey hashKeyAttr = method.getAnnotation(DynamoDBHashKey.class);
+                    String attrName = hashKeyAttr.attributeName();
+                    if (attrName == null || attrName.isEmpty()) {
+                        attrName = getAttributeName(method);
+                    }
+                    hashKey = new KeySchemaElement(attrName, KeyType.HASH);
+                    keySchema.add(0, hashKey);
+                    ScalarAttributeType attrType = getAttributeType(method);
+                    AttributeDefinition attribute = new AttributeDefinition(attrName, attrType);
+                    attributes.put(attrName, attribute);
+                } else if (method.isAnnotationPresent(DynamoDBRangeKey.class)) {
+                    // Range key
+                    DynamoDBRangeKey rangeKeyAttr = method.getAnnotation(DynamoDBRangeKey.class);
+                    String attrName = rangeKeyAttr.attributeName();
+                    if (attrName == null || attrName.isEmpty()) {
+                        attrName = getAttributeName(method);
+                    }
+                    KeySchemaElement rangeKey = new KeySchemaElement(attrName, KeyType.RANGE);
+                    keySchema.add(rangeKey);
+                    ScalarAttributeType attrType = getAttributeType(method);
+                    AttributeDefinition attribute = new AttributeDefinition(attrName, attrType);
+                    attributes.put(attrName, attribute);
+                }
+            }
+            if (hashKey == null) {
+                throw new RuntimeException("Missing hash key for DynamoDBTable " + clazz);
+            }
+            // This supports local indices, and global indices with a hash only or a hash and range.
+            for (Method method : methods) {
+                String attrName = null;
+                if (method.isAnnotationPresent(DynamoDBIndexHashKey.class)) {
+                    // There is no localSecondaryIndexName attribute, so this is by definition a global index
+                    // with a hash and range key. Find the range annotation to complete this description
+                    DynamoDBIndexHashKey indexKey = method.getAnnotation(DynamoDBIndexHashKey.class);
+                    attrName = indexKey.attributeName();
+                    if (isBlank(attrName)) {
+                        attrName = getAttributeName(method);
+                    }
+                    String indexName = indexKey.globalSecondaryIndexName();
+                    String rangeAttrName = findIndexRangeAttrName(clazz, true, indexName);
+                    GlobalSecondaryIndexDescription descr = createGlobalIndexDescr(
+                            indexName, attrName, rangeAttrName, throughput);
+                    addProjectionIfAnnotated(method, indexName, descr);
+                    globalIndices.add(descr);
+                } else if (method.isAnnotationPresent(DynamoDBIndexRangeKey.class)) {
+                    DynamoDBIndexRangeKey indexKey = method.getAnnotation(DynamoDBIndexRangeKey.class);
+                    attrName = indexKey.attributeName();
+                    if (isBlank(attrName)) {
+                        attrName = getAttributeName(method);
+                    }
+                    // Local index, range only, there are none of these in our code base (except for tests)
+                    String indexName = indexKey.localSecondaryIndexName();
+                    if (isNotBlank(indexName)) {
+                        // For a local index, the hash key is always the same hash key, it's only the range key tha
+                        // varies.
+                        // String hashAttrName = findIndexHashAttrName(clazz, indexName);
+                        LocalSecondaryIndexDescription descr = createLocalIndexDescr(indexName,
+                                        hashKey.getAttributeName(), attrName);
+                        localIndices.add(descr);
+                    }
+                    // If this is a range key but has no index, it hasn't been added yet, and needs to be added now.
+                    // So here we search for the accompanying hash annotation and if it exists, we skip adding this.
+                    indexName = indexKey.globalSecondaryIndexName();
+                    if (isNotBlank(indexName)) {
+                        String hashAttrName = findIndexHashAttrName(clazz, indexName);
+                        if (hashAttrName == null) {
+                            GlobalSecondaryIndexDescription descr = createGlobalIndexDescr(
+                                    indexName, null, attrName, throughput);
+                            addProjectionIfAnnotated(method, indexName, descr);
+                            globalIndices.add(descr);
+                        }
+                    }
+                }
+                if (attrName != null) {
+                    ScalarAttributeType attrType = getAttributeType(method);
+                    AttributeDefinition attribute = new AttributeDefinition(attrName, attrType);
+                    attributes.put(attrName, attribute);
+                }
+            }
+            final String tableName = DynamoUtils.getTableName(clazz, config);
+            // Create the table description
+            final TableDescription table = new TableDescription()
+                .withTableName(tableName)
+                .withKeySchema(keySchema)
+                .withAttributeDefinitions(attributes.values())
+                .withGlobalSecondaryIndexes(globalIndices)
+                .withLocalSecondaryIndexes(localIndices)
+                .withProvisionedThroughput(
+                    new ProvisionedThroughputDescription()
+                        .withReadCapacityUnits(throughput.getReadCapacityUnits())
+                        .withWriteCapacityUnits(throughput.getWriteCapacityUnits()));
+            tables.put(tableName, table);
+        }
+        return new ArrayList<>(tables.values());
+    }
+
+    private ProvisionedThroughput getThroughput(final Class<?> clazz) {
+        if (clazz.isAnnotationPresent(DynamoThroughput.class)) {
+            DynamoThroughput throughput = clazz.getAnnotation(DynamoThroughput.class);
+            return new ProvisionedThroughput(throughput.readCapacity(), throughput.writeCapacity());
+        }
+        return new ProvisionedThroughput(DEFAULT_READ_CAPACITY, DEFAULT_WRITE_CAPACITY);
+    }
+
+    /**
+     * If the method is also annotated with a projection annotation, use the projection it indicates. For hash/range
+     * global indices, this annotation needs to be on the same method as @DynamoDBIndexHashKey. This is a
+     * Bridge-specific annotation, it's not in the AWS SDK.
+     * 
+     * @param method
+     * @param indexName
+     * @param descr
+     */
+    private void addProjectionIfAnnotated(Method method, String indexName, GlobalSecondaryIndexDescription descr) {
+        DynamoProjection projection = method.getAnnotation(DynamoProjection.class);
+        if (projection != null && indexName.equals(projection.globalSecondaryIndexName())) {
+            descr.setProjection(new Projection().withProjectionType(projection.projectionType()));
+        }
+    }
+
+    private GlobalSecondaryIndexDescription createGlobalIndexDescr(String indexName, String hashAttrName,
+                    String rangeAttrName, ProvisionedThroughput throughput) {
+        checkArgument(isNotBlank(indexName));
+
+        List<KeySchemaElement> keys = Lists.newArrayList();
+        if (hashAttrName != null) {
+            keys.add(new KeySchemaElement(hashAttrName, KeyType.HASH));
+        }
+        if (rangeAttrName != null) {
+            keys.add(new KeySchemaElement(rangeAttrName, KeyType.RANGE));
+        }
+        GlobalSecondaryIndexDescription globalIndex = new GlobalSecondaryIndexDescription()
+            .withIndexName(indexName)
+            .withKeySchema(keys)
+            .withProjection(new Projection().withProjectionType(ProjectionType.KEYS_ONLY))
+            .withProvisionedThroughput(
+                new ProvisionedThroughputDescription()
+                    .withWriteCapacityUnits(throughput.getWriteCapacityUnits())
+                    .withReadCapacityUnits(throughput.getReadCapacityUnits()));
+        return globalIndex;
+    }
+
+    private LocalSecondaryIndexDescription createLocalIndexDescr(final String indexName, final String hashAttrName,
+                    final String rangeAttrName) {
+        final List<KeySchemaElement> keys = Lists.newArrayList();
+        if (hashAttrName != null) {
+            keys.add(new KeySchemaElement(hashAttrName, KeyType.HASH));
+        }
+        if (rangeAttrName != null) {
+            keys.add(new KeySchemaElement(rangeAttrName, KeyType.RANGE));
+        }
+        final LocalSecondaryIndexDescription localIndex = new LocalSecondaryIndexDescription().withIndexName(indexName)
+                        .withKeySchema(keys).withProjection(new Projection().withProjectionType(ProjectionType.ALL));
+        return localIndex;
+    }
+
+    private String findAttrName(final Class<?> clazz, final Function<Method, String> func) {
+        final Method[] methods = clazz.getMethods();
+        for (Method method : methods) {
+            final String attrName = func.apply(method);
+            if (attrName != null) {
+                return attrName;
+            }
+        }
+        return null;
+    }
+
+    private String findIndexHashAttrName(final Class<?> clazz, final String indexName) {
+        if (isBlank(indexName)) {
+            return null;
+        }
+        return findAttrName(clazz, new Function<Method, String>() {
+            public String apply(Method method) {
+                if (method.isAnnotationPresent(DynamoDBIndexHashKey.class)) {
+                    DynamoDBIndexHashKey indexKey = method.getAnnotation(DynamoDBIndexHashKey.class);
+                    String thisIndexName = indexKey.globalSecondaryIndexName();
+                    if (indexName.equals(thisIndexName)) {
+                        return indexKey.attributeName();
+                    }
+                }
+                return null;
+            }
+        });
+    }
+
+    private String findIndexRangeAttrName(final Class<?> clazz, final boolean isGlobal, final String indexName) {
+        if (isBlank(indexName)) {
+            return null;
+        }
+        return findAttrName(clazz, new Function<Method, String>() {
+            public String apply(Method method) {
+                if (method.isAnnotationPresent(DynamoDBIndexRangeKey.class)) {
+                    DynamoDBIndexRangeKey indexKey = method.getAnnotation(DynamoDBIndexRangeKey.class);
+                    String thisIndexName = isGlobal ? indexKey.globalSecondaryIndexName() : indexKey
+                                    .localSecondaryIndexName();
+                    if (indexName.equals(thisIndexName)) {
+                        return indexKey.attributeName();
+                    }
+                }
+                return null;
+            }
+        });
+    }
+
+    String getAttributeName(final Method method) {
+        String attrName = method.getName();
+        if (attrName.startsWith("get")) {
+            attrName = attrName.substring("get".length());
+            if (attrName.length() > 0) {
+                // Make sure the first letter is lower case
+                char[] chars = attrName.toCharArray();
+                chars[0] = Character.toLowerCase(chars[0]);
+                attrName = new String(chars);
+            }
+        }
+        return attrName;
+    }
+
+    ScalarAttributeType getAttributeType(final Method method) {
+        final Class<?> returnType = method.getReturnType();
+        if (returnType == String.class ||
+                returnType == JsonNode.class ||
+                returnType == LocalDate.class) {
+            return ScalarAttributeType.S;
+        } else if (returnType == Long.class ||
+                returnType == long.class ||
+                returnType == Integer.class ||
+                returnType == int.class) {
+            return ScalarAttributeType.N;
+        } else if (returnType == Boolean.class ||
+                returnType == boolean.class) {
+            return ScalarAttributeType.B;
+        }
+        throw new RuntimeException("Unsupported return type " + returnType
+                + " of method " + method.getName());
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoThroughput.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoThroughput.java
@@ -1,0 +1,13 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface DynamoThroughput {
+    long writeCapacity();
+    long readCapacity();
+}

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoUtils.java
@@ -73,26 +73,29 @@ public final class DynamoUtils {
 
     public static CreateTableRequest getCreateTableRequest(final TableDescription table) {
 
-        CreateTableRequest request = new CreateTableRequest().withTableName(table.getTableName())
-                        .withKeySchema(table.getKeySchema()).withAttributeDefinitions(table.getAttributeDefinitions());
+        checkNotNull(table);
+
+        final CreateTableRequest request = new CreateTableRequest()
+                .withTableName(table.getTableName())
+                .withKeySchema(table.getKeySchema())
+                .withAttributeDefinitions(table.getAttributeDefinitions());
 
         // ProvisionedThroughputDescription -> ProvisionedThroughput
-        ProvisionedThroughput throughput = new ProvisionedThroughput(table.getProvisionedThroughput()
-                        .getReadCapacityUnits(), table.getProvisionedThroughput().getWriteCapacityUnits());
+        final ProvisionedThroughput throughput = new ProvisionedThroughput(
+                table.getProvisionedThroughput().getReadCapacityUnits(),
+                table.getProvisionedThroughput().getWriteCapacityUnits());
         request.setProvisionedThroughput(throughput);
 
         // GlobalSecondaryIndexDescription -> GlobalSecondaryIndex
-        List<GlobalSecondaryIndex> globalIndices = new ArrayList<>();
-        List<GlobalSecondaryIndexDescription> globalIndexDescs = table.getGlobalSecondaryIndexes();
-        for (GlobalSecondaryIndexDescription globalIndexDesc : globalIndexDescs) {
-            GlobalSecondaryIndex globalIndex = new GlobalSecondaryIndex()
-                            .withIndexName(globalIndexDesc.getIndexName())
-                            .withKeySchema(globalIndexDesc.getKeySchema())
-                            .withProjection(globalIndexDesc.getProjection())
-                            .withProvisionedThroughput(
-                                            new ProvisionedThroughput(globalIndexDesc.getProvisionedThroughput()
-                                                            .getReadCapacityUnits(), globalIndexDesc
-                                                            .getProvisionedThroughput().getWriteCapacityUnits()));
+        final List<GlobalSecondaryIndex> globalIndices = new ArrayList<>();
+        for (GlobalSecondaryIndexDescription globalIndexDesc : table.getGlobalSecondaryIndexes()) {
+            final GlobalSecondaryIndex globalIndex = new GlobalSecondaryIndex()
+                    .withIndexName(globalIndexDesc.getIndexName())
+                    .withKeySchema(globalIndexDesc.getKeySchema())
+                    .withProjection(globalIndexDesc.getProjection())
+                    .withProvisionedThroughput(new ProvisionedThroughput(
+                            globalIndexDesc.getProvisionedThroughput().getReadCapacityUnits(),
+                            globalIndexDesc.getProvisionedThroughput().getWriteCapacityUnits()));
             globalIndices.add(globalIndex);
         }
         if (globalIndices.size() > 0) {
@@ -100,12 +103,12 @@ public final class DynamoUtils {
         }
 
         // LocalSecondaryIndexDescription -> LocalSecondaryIndex
-        List<LocalSecondaryIndex> localIndices = new ArrayList<>();
-        List<LocalSecondaryIndexDescription> localIndexDescs = table.getLocalSecondaryIndexes();
-        for (LocalSecondaryIndexDescription localIndexDesc : localIndexDescs) {
-            LocalSecondaryIndex localIndex = new LocalSecondaryIndex().withIndexName(localIndexDesc.getIndexName())
-                            .withKeySchema(localIndexDesc.getKeySchema())
-                            .withProjection(localIndexDesc.getProjection());
+        final List<LocalSecondaryIndex> localIndices = new ArrayList<>();
+        for (LocalSecondaryIndexDescription localIndexDesc : table.getLocalSecondaryIndexes()) {
+            final LocalSecondaryIndex localIndex = new LocalSecondaryIndex()
+                    .withIndexName(localIndexDesc.getIndexName())
+                    .withKeySchema(localIndexDesc.getKeySchema())
+                    .withProjection(localIndexDesc.getProjection());
             localIndices.add(localIndex);
         }
         if (localIndices.size() > 0) {
@@ -116,7 +119,8 @@ public final class DynamoUtils {
     }
 
     /**
-     * Compares hash key, range key of the two tables. Throws an exception if there is difference.
+     * Compares if the two tables are of the same name. Also compares hash key, range key of the two tables.
+     * Throws an exception if there is difference.
      */
     public static void compareSchema(final TableDescription table1, final TableDescription table2) {
         if (table1.getTableName().equals(table2.getTableName())) {
@@ -124,6 +128,9 @@ public final class DynamoUtils {
         }
     }
 
+    /**
+     * Compares hash key, range key of the two tables. Throws an exception if there is difference.
+     */
     public static void compareKeySchema(final TableDescription table1, final TableDescription table2) {
         List<KeySchemaElement> keySchema1 = table1.getKeySchema();
         List<KeySchemaElement> keySchema2 = table2.getKeySchema();

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoUtils.java
@@ -1,0 +1,153 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.sagebionetworks.bridge.config.Config;
+import org.sagebionetworks.bridge.config.Environment;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig.TableNameOverride;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
+import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndex;
+import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndexDescription;
+import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
+import com.amazonaws.services.dynamodbv2.model.LocalSecondaryIndex;
+import com.amazonaws.services.dynamodbv2.model.LocalSecondaryIndexDescription;
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
+import com.amazonaws.services.dynamodbv2.model.TableDescription;
+
+public final class DynamoUtils {
+
+    public static TableNameOverride getTableNameOverride(final Class<?> dynamoTable, final Config config) {
+        checkNotNull(dynamoTable);
+        checkNotNull(config);
+        final DynamoDBTable table = dynamoTable.getAnnotation(DynamoDBTable.class);
+        if (table == null) {
+            throw new IllegalArgumentException("Missing DynamoDBTable annotation for " + dynamoTable.getName());
+        }
+        final Environment env = config.getEnvironment();
+        return new TableNameOverride(env.name().toLowerCase() + "-" + config.getUser() + "-" + table.tableName());
+    }
+
+    public static String getTableName(final Class<?> dynamoTable, final Config config) {
+        return getTableNameOverride(dynamoTable, config).getTableName();
+    }
+
+    /**
+     * Gets the mapper with UPDATE behavior for saves and CONSISTENT reads.
+     */
+    public static DynamoDBMapper getMapper(final Class<?> dynamoTable, final Config config,
+            final AmazonDynamoDB dynamoClient) {
+        checkNotNull(dynamoTable);
+        checkNotNull(config);
+        checkNotNull(dynamoClient);
+        final DynamoDBMapperConfig mapperConfig = new DynamoDBMapperConfig.Builder()
+                .withSaveBehavior(DynamoDBMapperConfig.SaveBehavior.UPDATE)
+                .withConsistentReads(DynamoDBMapperConfig.ConsistentReads.CONSISTENT)
+                .withTableNameOverride(getTableNameOverride(dynamoTable, config)).build();
+        return new DynamoDBMapper(dynamoClient, mapperConfig);
+    }
+
+    /**
+     * Gets the mapper with UPDATE behavior for saves and EVENTUALLY consistent reads.
+     */
+    public static DynamoDBMapper getMapperEventually(final Class<?> dynamoTable, final Config config,
+            final AmazonDynamoDB dynamoClient) {
+        checkNotNull(dynamoTable);
+        checkNotNull(config);
+        checkNotNull(dynamoClient);
+        final DynamoDBMapperConfig mapperConfig = new DynamoDBMapperConfig.Builder()
+                .withSaveBehavior(DynamoDBMapperConfig.SaveBehavior.UPDATE)
+                .withConsistentReads(DynamoDBMapperConfig.ConsistentReads.EVENTUAL)
+                .withTableNameOverride(getTableNameOverride(dynamoTable, config)).build();
+        return new DynamoDBMapper(dynamoClient, mapperConfig);
+    }
+
+    public static CreateTableRequest getCreateTableRequest(final TableDescription table) {
+
+        CreateTableRequest request = new CreateTableRequest().withTableName(table.getTableName())
+                        .withKeySchema(table.getKeySchema()).withAttributeDefinitions(table.getAttributeDefinitions());
+
+        // ProvisionedThroughputDescription -> ProvisionedThroughput
+        ProvisionedThroughput throughput = new ProvisionedThroughput(table.getProvisionedThroughput()
+                        .getReadCapacityUnits(), table.getProvisionedThroughput().getWriteCapacityUnits());
+        request.setProvisionedThroughput(throughput);
+
+        // GlobalSecondaryIndexDescription -> GlobalSecondaryIndex
+        List<GlobalSecondaryIndex> globalIndices = new ArrayList<>();
+        List<GlobalSecondaryIndexDescription> globalIndexDescs = table.getGlobalSecondaryIndexes();
+        for (GlobalSecondaryIndexDescription globalIndexDesc : globalIndexDescs) {
+            GlobalSecondaryIndex globalIndex = new GlobalSecondaryIndex()
+                            .withIndexName(globalIndexDesc.getIndexName())
+                            .withKeySchema(globalIndexDesc.getKeySchema())
+                            .withProjection(globalIndexDesc.getProjection())
+                            .withProvisionedThroughput(
+                                            new ProvisionedThroughput(globalIndexDesc.getProvisionedThroughput()
+                                                            .getReadCapacityUnits(), globalIndexDesc
+                                                            .getProvisionedThroughput().getWriteCapacityUnits()));
+            globalIndices.add(globalIndex);
+        }
+        if (globalIndices.size() > 0) {
+            request.setGlobalSecondaryIndexes(globalIndices);
+        }
+
+        // LocalSecondaryIndexDescription -> LocalSecondaryIndex
+        List<LocalSecondaryIndex> localIndices = new ArrayList<>();
+        List<LocalSecondaryIndexDescription> localIndexDescs = table.getLocalSecondaryIndexes();
+        for (LocalSecondaryIndexDescription localIndexDesc : localIndexDescs) {
+            LocalSecondaryIndex localIndex = new LocalSecondaryIndex().withIndexName(localIndexDesc.getIndexName())
+                            .withKeySchema(localIndexDesc.getKeySchema())
+                            .withProjection(localIndexDesc.getProjection());
+            localIndices.add(localIndex);
+        }
+        if (localIndices.size() > 0) {
+            request.setLocalSecondaryIndexes(localIndices);
+        }
+
+        return request;
+    }
+
+    /**
+     * Compares hash key, range key of the two tables. Throws an exception if there is difference.
+     */
+    public static void compareSchema(final TableDescription table1, final TableDescription table2) {
+        if (table1.getTableName().equals(table2.getTableName())) {
+            compareKeySchema(table1, table2);
+        }
+    }
+
+    public static void compareKeySchema(final TableDescription table1, final TableDescription table2) {
+        List<KeySchemaElement> keySchema1 = table1.getKeySchema();
+        List<KeySchemaElement> keySchema2 = table2.getKeySchema();
+        compareKeySchema(keySchema1, keySchema2);
+    }
+
+    private static void compareKeySchema(final List<KeySchemaElement> keySchema1, final List<KeySchemaElement> keySchema2) {
+        if (keySchema1.size() != keySchema2.size()) {
+            throw new KeySchemaMismatchException("Key schemas have different number of key elements.");
+        }
+        final Map<String, KeySchemaElement> keySchemaMap1 = new HashMap<>();
+        for (KeySchemaElement ele1 : keySchema1) {
+            keySchemaMap1.put(ele1.getAttributeName(), ele1);
+        }
+        for (KeySchemaElement ele2 : keySchema2) {
+            KeySchemaElement ele1 = keySchemaMap1.get(ele2.getAttributeName());
+            if (ele1 == null) {
+                throw new KeySchemaMismatchException("Missing key " + ele2.getAttributeName() + " in schema 1.");
+            }
+            if (!ele1.equals(ele2)) {
+                throw new KeySchemaMismatchException("Different key schema for key " + ele2.getAttributeName());
+            }
+        }
+    }
+
+    private DynamoUtils() {}
+}

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/KeySchemaMismatchException.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/KeySchemaMismatchException.java
@@ -1,0 +1,9 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+@SuppressWarnings("serial")
+public class KeySchemaMismatchException extends RuntimeException {
+
+    public KeySchemaMismatchException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/redis/JedisOps.java
+++ b/src/main/java/org/sagebionetworks/bridge/redis/JedisOps.java
@@ -1,0 +1,173 @@
+package org.sagebionetworks.bridge.redis;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+public class JedisOps {
+
+    private final JedisPool jedisPool;
+
+    public JedisOps(JedisPool jedisPool) {
+        this.jedisPool = jedisPool;
+    }
+
+    /**
+     * The specified key will expire after seconds.
+     *
+     * @param key
+     *            target key.
+     * @param seconds
+     *            number of seconds until expiration.
+     * @return success code
+     *          1 if successful, 0 if key doesn't exist or timeout could not be set
+     */
+    public Long expire(final String key, final int seconds) {
+        return new AbstractJedisTemplate<Long>() {
+            @Override
+            Long execute(Jedis jedis) {
+                return jedis.expire(key, seconds);
+            }
+        }.execute();
+    }
+
+    /**
+     * Sets the value of the key and makes it expire after the specified
+     * seconds.
+     *
+     * @param key
+     *            key of the key-value pair.
+     * @param seconds
+     *            number of seconds until expiration.
+     * @param value
+     *            value of the key-value pair.
+     */
+    public String setex(final String key, final int seconds, final String value) {
+        return new AbstractJedisTemplate<String>() {
+            @Override
+            String execute(Jedis jedis) {
+                return jedis.setex(key, seconds, value);
+            }
+        }.execute();
+    }
+
+    /**
+     * Sets the value of the key if and only if the key does not already have a
+     * value.
+     *
+     * @param key
+     *            key of the key-value pair.
+     * @param value
+     *            value of the key-value pair.
+     * @return success code
+     *          1 if the key was set, 0 if not
+     */
+    public Long setnx(final String key, final String value) {
+        return new AbstractJedisTemplate<Long>() {
+            @Override
+            Long execute(Jedis jedis) {
+                return jedis.setnx(key, value);
+            }
+        }.execute();
+    }
+
+    /**
+     * Gets the value of the specified key. If the key does not exist null is
+     * returned.
+     */
+    public String get(final String key) {
+        return new AbstractJedisTemplate<String>() {
+            @Override
+            String execute(Jedis jedis) {
+                return jedis.get(key);
+            }
+        }.execute();
+    }
+
+    /**
+     * Deletes the specified list of keys.
+     *
+     * @param keys
+     *            the list of keys to be deleted.
+     * @return number of keys deleted
+     */
+    public Long del(final String... keys) {
+        return new AbstractJedisTemplate<Long>() {
+            @Override
+            Long execute(Jedis jedis) {
+                return jedis.del(keys);
+            }
+        }.execute();
+    }
+
+    /**
+     * Determines the time until expiration for a key (time-to-live).
+     *
+     * @param key
+     *            key of the key-value pair.
+     * @return ttl
+     *      positive value if ttl is set, zero if not, negative if there was an error
+     */
+    public Long ttl(final String key) {
+        return new AbstractJedisTemplate<Long>() {
+            @Override
+            Long execute(Jedis jedis) {
+                return jedis.ttl(key);
+            }
+        }.execute();
+    }
+
+    /**
+     * Increments the value by one.
+     *
+     * @return the new value of the key after incrementing.
+     */
+    public Long incr(final String key) {
+        return new AbstractJedisTemplate<Long>() {
+            @Override
+            Long execute(Jedis jedis) {
+                return jedis.incr(key);
+            }
+        }.execute();
+    }
+
+    /**
+     * Decrements the value by one.
+     *
+     * @return the new value of the key after decrementing.
+     */
+    public Long decr(final String key) {
+        return new AbstractJedisTemplate<Long>() {
+            @Override
+            Long execute(Jedis jedis) {
+                return jedis.decr(key);
+            }
+        }.execute();
+    }
+
+    /**
+     * Starts a transaction with the optional list of keys to watch.
+     *
+     * @param keys
+     *            The optional list of keys to watch.
+     * @return The transaction object.
+     */
+    public JedisTransaction getTransaction(final String... keys) {
+        final Jedis jedis = jedisPool.getResource();
+        if (keys != null && keys.length > 0) {
+            jedis.watch(keys);
+        }
+        return new JedisTransaction(jedis);
+    }
+
+    /**
+     * Responsible for providing template code such as closing resources.
+     */
+    private abstract class AbstractJedisTemplate<T> {
+        T execute() {
+            try (Jedis jedis = jedisPool.getResource()) {
+                return execute(jedis);
+            }
+        }
+        abstract T execute(final Jedis jedis);
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/redis/JedisTransaction.java
+++ b/src/main/java/org/sagebionetworks/bridge/redis/JedisTransaction.java
@@ -1,0 +1,45 @@
+package org.sagebionetworks.bridge.redis;
+
+import java.util.List;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Transaction;
+
+public class JedisTransaction implements AutoCloseable {
+
+    private final Jedis jedis;
+    private final Transaction transaction;
+
+    JedisTransaction(Jedis jedis) {
+        this.jedis = jedis;
+        this.transaction = jedis.multi();
+    }
+
+    public JedisTransaction setex(final String key, final int seconds, final String value) {
+        transaction.setex(key, seconds, value);
+        return this;
+    }
+
+    public JedisTransaction expire(final String key, final int seconds) {
+        transaction.expire(key, seconds);
+        return this;
+    }
+
+    public JedisTransaction del(final String key) {
+        transaction.del(key);
+        return this;
+    }
+
+    public List<Object> exec() {
+        return transaction.exec();
+    }
+
+    public String discard() {
+        return transaction.discard();
+    }
+
+    @Override
+    public void close() {
+        jedis.close();
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoTableMapperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoTableMapperTest.java
@@ -1,0 +1,106 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+import org.sagebionetworks.bridge.config.Environment;
+import org.sagebionetworks.bridge.dynamodb.test.TestHealthDataRecord;
+
+import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndexDescription;
+import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
+import com.amazonaws.services.dynamodbv2.model.TableDescription;
+
+public class DynamoTableMapperTest {
+
+    @Test
+    public void testGetAnnotatedTables() {
+        List<TableDescription> tables = DynamoTestUtils.MAPPER.getTables();
+        assertNotNull(tables);
+        assertEquals(2, tables.size());
+        Map<String, TableDescription> tableMap = new HashMap<String, TableDescription>();
+        for (TableDescription table : tables) {
+            tableMap.put(table.getTableName(), table);
+        }
+        String tableName = Environment.LOCAL.name().toLowerCase() + "-"
+                + DynamoTestUtils.class.getSimpleName() + "-TestHealthDataRecord";
+        TableDescription table = tableMap.get(tableName);
+        assertNotNull(table);
+        assertEquals(2, table.getKeySchema().size());
+        assertEquals(5, table.getAttributeDefinitions().size());
+        assertEquals(2, table.getLocalSecondaryIndexes().size());
+        assertEquals(1, table.getGlobalSecondaryIndexes().size());
+        assertEquals(30L, table.getProvisionedThroughput().getReadCapacityUnits().longValue());
+        assertEquals(50L, table.getProvisionedThroughput().getWriteCapacityUnits().longValue());
+    }
+
+    @Test
+    public void testLoadDynamoTableClasses() {
+        List<Class<?>> classes = DynamoTestUtils.MAPPER.loadDynamoTableClasses();
+        assertNotNull(classes);
+        assertEquals(2, classes.size());
+        Set<String> classSet = new HashSet<String>();
+        for (Class<?> clazz : classes) {
+            classSet.add(clazz.getName());
+        }
+        assertTrue(classSet.contains("org.sagebionetworks.bridge.dynamodb.test.TestHealthDataRecord"));
+    }
+
+    @Test
+    public void testGetAttributeName() throws Exception {
+        DynamoTableMapper mapper = DynamoTestUtils.MAPPER;
+        Method method = TestHealthDataRecord.class.getMethod("getStartDate");
+        assertEquals("startDate", mapper.getAttributeName(method));
+        method = TestHealthDataRecord.class.getMethod("hashCode");
+        assertEquals("hashCode", mapper.getAttributeName(method));
+    }
+
+    @Test
+    public void testGetAttributeType() throws Exception {
+        DynamoTableMapper mapper = DynamoTestUtils.MAPPER;
+        Method method = TestHealthDataRecord.class.getMethod("getStartDate");
+        assertEquals(ScalarAttributeType.N, mapper.getAttributeType(method));
+        method = TestHealthDataRecord.class.getMethod("getData");
+        assertEquals(ScalarAttributeType.S, mapper.getAttributeType(method));
+    }
+
+    @Test
+    public void createsGlobalIndices() {
+        List<TableDescription> tables = DynamoTestUtils.MAPPER.getTables();
+        TableDescription table = DynamoTestUtils.getTableByName(tables, "TestTask");
+        assertEquals(3, table.getGlobalSecondaryIndexes().size());
+
+        GlobalSecondaryIndexDescription index = findIndex(table.getGlobalSecondaryIndexes(), "guid-index");
+        assertEquals("INCLUDE", index.getProjection().getProjectionType());
+        assertEquals("guid", index.getKeySchema().get(0).getAttributeName());
+        assertEquals(Long.valueOf(18), index.getProvisionedThroughput().getWriteCapacityUnits());
+        assertEquals(Long.valueOf(20), index.getProvisionedThroughput().getReadCapacityUnits());
+
+        index = findIndex(table.getGlobalSecondaryIndexes(), "healthCode-scheduledOn-index");
+        assertEquals("ALL", index.getProjection().getProjectionType());
+        assertEquals("healthCode", index.getKeySchema().get(0).getAttributeName());
+        assertEquals("scheduledOn", index.getKeySchema().get(1).getAttributeName());
+        assertEquals(Long.valueOf(18), index.getProvisionedThroughput().getWriteCapacityUnits());
+        assertEquals(Long.valueOf(20), index.getProvisionedThroughput().getReadCapacityUnits());
+
+        index = findIndex(table.getGlobalSecondaryIndexes(), "healthCode-expiresOn-index");
+        assertEquals("expiresOn", index.getKeySchema().get(0).getAttributeName());
+    }
+
+    private GlobalSecondaryIndexDescription findIndex(List<GlobalSecondaryIndexDescription> list, String name) {
+        for (GlobalSecondaryIndexDescription index : list) {
+            if (index.getIndexName().equals(name)) {
+                return index;
+            }
+        }
+        return null;
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoTableMapperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoTableMapperTest.java
@@ -56,7 +56,7 @@ public class DynamoTableMapperTest {
 
     @Test
     public void testGetAttributeName() throws Exception {
-        DynamoTableMapper mapper = DynamoTestUtils.MAPPER;
+        AnnotationBasedTableCreator mapper = DynamoTestUtils.MAPPER;
         Method method = TestHealthDataRecord.class.getMethod("getStartDate");
         assertEquals("startDate", mapper.getAttributeName(method));
         method = TestHealthDataRecord.class.getMethod("hashCode");
@@ -65,7 +65,7 @@ public class DynamoTableMapperTest {
 
     @Test
     public void testGetAttributeType() throws Exception {
-        DynamoTableMapper mapper = DynamoTestUtils.MAPPER;
+        AnnotationBasedTableCreator mapper = DynamoTestUtils.MAPPER;
         Method method = TestHealthDataRecord.class.getMethod("getStartDate");
         assertEquals(ScalarAttributeType.N, mapper.getAttributeType(method));
         method = TestHealthDataRecord.class.getMethod("getData");

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoTestUtils.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoTestUtils.java
@@ -1,0 +1,52 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import java.util.List;
+
+import org.sagebionetworks.bridge.config.Config;
+import org.sagebionetworks.bridge.config.Environment;
+
+import com.amazonaws.services.dynamodbv2.model.TableDescription;
+
+public final class DynamoTestUtils {
+
+    static final String PACKAGE = "org.sagebionetworks.bridge.dynamodb.test";
+
+    static final Config CONFIG = new Config() {
+        @Override
+        public String getUser() {
+            return DynamoTestUtils.class.getSimpleName();
+        }
+        @Override
+        public Environment getEnvironment() {
+            return Environment.LOCAL;
+        }
+        @Override
+        public String get(String key) {
+            return null;
+        }
+        @Override
+        public int getInt(String key) {
+            return 0;
+        }
+        @Override
+        public List<String> getList(String key) {
+            return null;
+        }
+    };
+
+    static final DynamoTableMapper MAPPER = new DynamoTableMapper(DynamoTestUtils.PACKAGE, DynamoTestUtils.CONFIG);
+
+    /**
+     * Finds the first table that matches the supplied partial name.
+     */
+    static TableDescription getTableByName(final List<TableDescription> tables, final String partialTableName) {
+        for (TableDescription table : tables) {
+            if (table.getTableName().indexOf(partialTableName) > -1) {
+                return table;
+            }
+        }
+        return null;
+    }
+
+    private DynamoTestUtils() {}
+}

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoTestUtils.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoTestUtils.java
@@ -34,7 +34,7 @@ public final class DynamoTestUtils {
         }
     };
 
-    static final DynamoTableMapper MAPPER = new DynamoTableMapper(DynamoTestUtils.PACKAGE, DynamoTestUtils.CONFIG);
+    static final AnnotationBasedTableCreator MAPPER = new AnnotationBasedTableCreator(DynamoTestUtils.PACKAGE, DynamoTestUtils.CONFIG);
 
     /**
      * Finds the first table that matches the supplied partial name.

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoUtilsTest.java
@@ -1,0 +1,122 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
+import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
+import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndex;
+import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndexDescription;
+import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
+import com.amazonaws.services.dynamodbv2.model.LocalSecondaryIndex;
+import com.amazonaws.services.dynamodbv2.model.LocalSecondaryIndexDescription;
+import com.amazonaws.services.dynamodbv2.model.TableDescription;
+
+public class DynamoUtilsTest {
+
+    @Test
+    public void testGetCreateTableRequest() {
+
+        List<TableDescription> tables = DynamoTestUtils.MAPPER.getTables();
+        TableDescription table = DynamoTestUtils.getTableByName(tables, "TestHealthDataRecord");
+        CreateTableRequest request = DynamoUtils.getCreateTableRequest(table);
+        assertNotNull(request);
+
+        // KeySchema
+        List<KeySchemaElement> keySchema = request.getKeySchema();
+        assertNotNull(keySchema);
+        assertEquals(2, keySchema.size());
+        Map<String, KeySchemaElement> keyElements = new HashMap<String, KeySchemaElement>();
+        for (KeySchemaElement ele : keySchema) {
+            keyElements.put(ele.getAttributeName(), ele);
+        }
+        assertEquals("HASH", keyElements.get("key").getKeyType());
+        assertEquals("RANGE", keyElements.get("recordId").getKeyType());
+        assertEquals("HASH", keySchema.get(0).getKeyType()); // The first key must be the hashkey
+
+        // Local indices
+        List<LocalSecondaryIndex> localIndices = request.getLocalSecondaryIndexes();
+        assertNotNull(localIndices);
+        assertEquals(2, localIndices.size());
+        Map<String, LocalSecondaryIndex> localIndexMap = new HashMap<String, LocalSecondaryIndex>();
+        for (LocalSecondaryIndex idx : localIndices) {
+            localIndexMap.put(idx.getIndexName(), idx);
+        }
+        assertNotNull(localIndexMap.get("startDate-index"));
+        assertNotNull(localIndexMap.get("endDate-index"));
+
+        // global indices
+        List<GlobalSecondaryIndex> globalIndexList = request.getGlobalSecondaryIndexes();
+        assertEquals(1, globalIndexList.size());
+        assertEquals("secondary-index", globalIndexList.get(0).getIndexName());
+
+        // Attributes
+        List<AttributeDefinition> attributes = request.getAttributeDefinitions();
+        assertNotNull(attributes);
+        assertEquals(5, attributes.size());
+
+        // Throughput
+        assertEquals(30L, request.getProvisionedThroughput().getReadCapacityUnits().longValue());
+        assertEquals(50L, request.getProvisionedThroughput().getWriteCapacityUnits().longValue());
+    }
+
+    @Test
+    public void testCompareSchema() {
+        List<TableDescription> tables = DynamoTestUtils.MAPPER.getTables();
+        TableDescription table1 = tables.get(0);
+        TableDescription table2 = copyTableDescription(table1);
+        // No exception
+        DynamoUtils.compareSchema(table1, table2);
+    }
+
+    @Test(expected = KeySchemaMismatchException.class)
+    public void testCompareSchemaDifferentKeys() {
+        List<TableDescription> tables = DynamoTestUtils.MAPPER.getTables();
+        TableDescription table1 = tables.get(0);
+        TableDescription table2 = copyTableDescription(table1);
+        table2.getKeySchema().get(0).setAttributeName("some fake attr name");
+        DynamoUtils.compareSchema(table1, table2);
+    }
+
+    // Copies the relevant attributes from a table (name, keys, global and local secondary indices)
+    private static TableDescription copyTableDescription(TableDescription table1) {
+        TableDescription table2 = new TableDescription();
+        table2.setTableName(table1.getTableName());
+
+        // key schema
+        table2.setKeySchema(new ArrayList<KeySchemaElement>());
+        for (KeySchemaElement ele : table1.getKeySchema()) {
+            table2.getKeySchema().add(new KeySchemaElement(ele.getAttributeName(), ele.getKeyType()));
+        }
+
+        // global indices
+        table2.setGlobalSecondaryIndexes(new ArrayList<GlobalSecondaryIndexDescription>());
+        for (GlobalSecondaryIndexDescription index : table1.getGlobalSecondaryIndexes()) {
+            table2.getGlobalSecondaryIndexes().add(
+                    new GlobalSecondaryIndexDescription()
+                            .withIndexName(index.getIndexName())
+                            .withKeySchema(index.getKeySchema())
+                            .withProjection(index.getProjection())
+                            .withProvisionedThroughput(index.getProvisionedThroughput()));
+        }
+
+        // local indices
+        table2.setLocalSecondaryIndexes(new ArrayList<LocalSecondaryIndexDescription>());
+        for (LocalSecondaryIndexDescription index : table1.getLocalSecondaryIndexes()) {
+            table2.getLocalSecondaryIndexes().add(
+                    new LocalSecondaryIndexDescription()
+                            .withIndexName(index.getIndexName())
+                            .withKeySchema(index.getKeySchema())
+                            .withProjection(index.getProjection()));
+        }
+
+        return table2;
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/test/TestHealthDataRecord.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/test/TestHealthDataRecord.java
@@ -1,0 +1,92 @@
+package org.sagebionetworks.bridge.dynamodb.test;
+
+import org.sagebionetworks.bridge.dynamodb.DynamoThroughput;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexRangeKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBVersionAttribute;
+import com.fasterxml.jackson.databind.JsonNode;
+
+// This class is based on an older version of HealthDataRecord, but is really just a dummy table used to test
+// DynamoInitializer.
+@DynamoThroughput(writeCapacity = 50, readCapacity = 30)
+@DynamoDBTable(tableName = "TestHealthDataRecord")
+public class TestHealthDataRecord {
+
+    private String key;
+    private String guid;
+    private long startDate;
+    private long endDate;
+    private String secondaryKey;
+    private Long version;
+    private JsonNode data;
+
+    public TestHealthDataRecord() {
+    }
+
+    public TestHealthDataRecord(String key) {
+        this.key = key;
+    }
+
+    @DynamoDBHashKey
+    public String getKey() {
+        return key;
+    }
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    @DynamoDBRangeKey(attributeName="recordId")
+    public String getGuid() {
+        return guid;
+    }
+    public void setGuid(String guid) {
+        this.guid = guid;
+    }
+
+    @DynamoDBAttribute
+    @DynamoDBIndexRangeKey(attributeName = "startDate", localSecondaryIndexName = "startDate-index")
+    public long getStartDate() {
+        return startDate;
+    }
+    public void setStartDate(long startDate) {
+        this.startDate = startDate;
+    }
+
+    @DynamoDBAttribute
+    @DynamoDBIndexRangeKey(attributeName = "endDate", localSecondaryIndexName = "endDate-index")
+    public long getEndDate() {
+        return endDate;
+    }
+    public void setEndDate(long endDate) {
+        this.endDate = endDate;
+    }
+
+    @DynamoDBIndexHashKey(attributeName = "secondaryKey", globalSecondaryIndexName = "secondary-index")
+    public String getSecondaryKey() {
+        return secondaryKey;
+    }
+    public void setSecondaryKey(String secondaryKey) {
+        this.secondaryKey = secondaryKey;
+    }
+
+    @DynamoDBAttribute
+    public JsonNode getData() {
+        return data;
+    }
+    public void setData(JsonNode payload) {
+        this.data = payload;
+    }
+
+    @DynamoDBVersionAttribute
+    public Long getVersion() {
+        return version;
+    }
+    public void setVersion(Long version) {
+        this.version = version;
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/test/TestTask.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/test/TestTask.java
@@ -1,0 +1,80 @@
+package org.sagebionetworks.bridge.dynamodb.test;
+
+import org.sagebionetworks.bridge.dynamodb.DynamoProjection;
+import org.sagebionetworks.bridge.dynamodb.DynamoThroughput;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexRangeKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+import com.amazonaws.services.dynamodbv2.model.ProjectionType;
+
+@DynamoDBTable(tableName = "TestTask")
+@DynamoThroughput(writeCapacity=18L, readCapacity=20L)
+public class TestTask {
+
+    private String healthCode;
+    private String guid;
+    private String schedulePlanGuid;
+    private Long scheduledOn;
+    private Long expiresOn;
+    private Long startedOn;
+    private Long finishedOn;
+
+    @DynamoDBHashKey
+    @DynamoDBIndexHashKey(attributeName = "healthCode", globalSecondaryIndexName = "healthCode-scheduledOn-index")
+    @DynamoProjection(projectionType=ProjectionType.ALL, globalSecondaryIndexName = "healthCode-scheduledOn-index")
+    public String getHealthCode() {
+        return healthCode;
+    }
+    public void setHealthCode(String healthCode) {
+        this.healthCode = healthCode;
+    }
+    @DynamoDBRangeKey
+    @DynamoDBIndexHashKey(attributeName = "guid", globalSecondaryIndexName ="guid-index")
+    @DynamoProjection(projectionType=ProjectionType.INCLUDE, globalSecondaryIndexName = "guid-index")
+    public String getGuid() {
+        return guid;
+    }
+    public void setGuid(String guid) {
+        this.guid = guid;
+    }
+    @DynamoDBAttribute
+    public String getSchedulePlanGuid() {
+        return schedulePlanGuid;
+    }
+    public void setSchedulePlanGuid(String schedulePlanGuid) {
+        this.schedulePlanGuid = schedulePlanGuid;
+    }
+    @DynamoDBIndexRangeKey(attributeName = "scheduledOn", globalSecondaryIndexName = "healthCode-scheduledOn-index")
+    public Long getScheduledOn() {
+        return scheduledOn;
+    }
+    public void setScheduledOn(Long scheduledOn) {
+        this.scheduledOn = scheduledOn;
+    }
+    @DynamoDBIndexRangeKey(attributeName = "expiresOn", globalSecondaryIndexName = "healthCode-expiresOn-index")
+    @DynamoDBAttribute
+    public Long getExpiresOn() {
+        return expiresOn;
+    }
+    public void setExpiresOn(Long expiresOn) {
+        this.expiresOn = expiresOn;
+    }
+    @DynamoDBAttribute
+    public Long getStartedOn() {
+        return startedOn;
+    }
+    public void setStartedOn(Long startedOn) {
+        this.startedOn = startedOn;
+    }
+    @DynamoDBAttribute
+    public Long getFinishedOn() {
+        return finishedOn;
+    }
+    public void setFinishedOn(Long finishedOn) {
+        this.finishedOn = finishedOn;
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/test/package-info.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/test/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * This package is for testing DynamoInitializer so that, during testing,
+ * only DynamoDB tables defined in this package are initialized.
+ */
+package org.sagebionetworks.bridge.dynamodb.test;

--- a/src/test/java/org/sagebionetworks/bridge/redis/JedisTransactionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/redis/JedisTransactionTest.java
@@ -1,0 +1,30 @@
+package org.sagebionetworks.bridge.redis;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Transaction;
+
+public class JedisTransactionTest {
+
+    @Test
+    public void test() {
+        Transaction transaction = mock(Transaction.class);
+        InOrder inOrder = inOrder(transaction);
+        Jedis jedis = mock(Jedis.class);
+        when(jedis.multi()).thenReturn(transaction);
+        try (JedisTransaction jt = new JedisTransaction(jedis)) {
+            jt.setex("k1", 10, "v1").expire("k1", 15).del("k2").exec();
+            inOrder.verify(transaction, times(1)).setex("k1", 10, "v1");
+            inOrder.verify(transaction, times(1)).expire("k1", 15);
+            inOrder.verify(transaction, times(1)).del("k2");
+            inOrder.verify(transaction, times(1)).exec();
+        }
+    }
+}


### PR DESCRIPTION
with the following refactoring:

1) Instead of moving the entire DynamoIntializer, looked at the part that maps annotated tables to DynamoDB's TableDescription and moved it to a new class TableMapper.

2) Moved methods like compareSchema() and getCreateTableRequest() to DynamoUtils.
