### PR TITLE
updates to S3Helper and UploadSchemas to support Bridge EX 2.0

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/s3/S3Helper.java
+++ b/src/main/java/org/sagebionetworks/bridge/s3/S3Helper.java
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeUnit;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import com.google.common.base.Charsets;
 import com.google.common.io.ByteStreams;
@@ -33,6 +34,23 @@ public class S3Helper {
      */
     public final void setS3Client(AmazonS3Client s3Client) {
         this.s3Client = s3Client;
+    }
+
+    /**
+     * Downloads a file from S3 directly to the specified file.
+     *
+     * @param bucket
+     *         S3 bucket to download from
+     * @param key
+     *         S3 key to download from
+     * @param destinationFile
+     *         file to download to
+     */
+    @RetryOnFailure(attempts = 5, delay = 100, unit = TimeUnit.MILLISECONDS, types = AmazonClientException.class,
+            randomize = false)
+    public void downloadS3File(String bucket, String key, File destinationFile) {
+        GetObjectRequest s3Request = new GetObjectRequest(bucket, key);
+        s3Client.getObject(s3Request, destinationFile);
     }
 
     /**

--- a/src/main/java/org/sagebionetworks/bridge/schema/UploadFieldTypes.java
+++ b/src/main/java/org/sagebionetworks/bridge/schema/UploadFieldTypes.java
@@ -1,0 +1,18 @@
+package org.sagebionetworks.bridge.schema;
+
+/** Utility class that contains constants for Upload field types. */
+// TODO: Make this into an enum and consolidate it with the corresponding BridgePF class.
+@SuppressWarnings("unused")
+public class UploadFieldTypes {
+    public static final String ATTACHMENT_BLOB = "ATTACHMENT_BLOB";
+    public static final String ATTACHMENT_CSV = "ATTACHMENT_CSV";
+    public static final String ATTACHMENT_JSON_BLOB = "ATTACHMENT_JSON_BLOB";
+    public static final String ATTACHMENT_JSON_TABLE = "ATTACHMENT_JSON_TABLE";
+    public static final String BOOLEAN = "BOOLEAN";
+    public static final String CALENDAR_DATE = "CALENDAR_DATE";
+    public static final String FLOAT = "FLOAT";
+    public static final String INLINE_JSON_BLOB = "INLINE_JSON_BLOB";
+    public static final String INT = "INT";
+    public static final String STRING = "STRING";
+    public static final String TIMESTAMP = "TIMESTAMP";
+}

--- a/src/main/java/org/sagebionetworks/bridge/schema/UploadSchema.java
+++ b/src/main/java/org/sagebionetworks/bridge/schema/UploadSchema.java
@@ -16,11 +16,13 @@ import com.google.common.collect.ImmutableSet;
 import org.sagebionetworks.bridge.json.DefaultObjectMapper;
 
 /** Represents an upload schema, including key, field names, and field types. */
+// TODO: Consolidate this with BridgePF code.
 public class UploadSchema {
     /** Set of field types that are considered attachments. */
     @SuppressWarnings("unused")
-    public static final Set<String> ATTACHMENT_TYPE_SET = ImmutableSet.of("ATTACHMENT_BLOB", "ATTACHMENT_CSV",
-            "ATTACHMENT_JSON_BLOB", "ATTACHMENT_JSON_TABLE");
+    public static final Set<String> ATTACHMENT_TYPE_SET = ImmutableSet.of(UploadFieldTypes.ATTACHMENT_BLOB,
+            UploadFieldTypes.ATTACHMENT_CSV, UploadFieldTypes.ATTACHMENT_JSON_BLOB,
+            UploadFieldTypes.ATTACHMENT_JSON_TABLE);
 
     private final UploadSchemaKey key;
     private final List<String> fieldNameList;

--- a/src/main/java/org/sagebionetworks/bridge/schema/UploadSchemaKey.java
+++ b/src/main/java/org/sagebionetworks/bridge/schema/UploadSchemaKey.java
@@ -1,9 +1,11 @@
 package org.sagebionetworks.bridge.schema;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Objects;
 import org.apache.commons.lang3.StringUtils;
 
 /** This class represents an upload schema key, with a study ID, schema ID, and revision. */
+@JsonDeserialize(builder = UploadSchemaKey.Builder.class)
 public final class UploadSchemaKey {
     private final String studyId;
     private final String schemaId;

--- a/src/test/java/org/sagebionetworks/bridge/s3/S3HelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/s3/S3HelperTest.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.s3;
 
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
+import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -15,6 +16,7 @@ import java.util.List;
 
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
@@ -27,6 +29,26 @@ import org.testng.annotations.Test;
 public class S3HelperTest {
     // Test strategy is that given a mock input stream from a mock S3 object, the S3Helper can still turn that
     // input stream into a byte array or a string.
+
+    @Test
+    public void downloadS3File() {
+        // Mock S3 client. Setup S3 helper
+        AmazonS3Client mockS3Client = mock(AmazonS3Client.class);
+        S3Helper s3Helper = new S3Helper();
+        s3Helper.setS3Client(mockS3Client);
+
+        // execute
+        File mockFile = mock(File.class);
+        s3Helper.downloadS3File("test-bucket", "test-key", mockFile);
+
+        // The inner S3 client does all the work. Validate that we passed args to it correctly.
+        ArgumentCaptor<GetObjectRequest> requestCaptor = ArgumentCaptor.forClass(GetObjectRequest.class);
+        verify(mockS3Client).getObject(requestCaptor.capture(), same(mockFile));
+
+        GetObjectRequest request = requestCaptor.getValue();
+        assertEquals(request.getBucketName(), "test-bucket");
+        assertEquals(request.getKey(), "test-key");
+    }
 
     @Test
     public void generatePresignedUrl() throws Exception {

--- a/src/test/java/org/sagebionetworks/bridge/schema/UploadSchemaKeyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/schema/UploadSchemaKeyTest.java
@@ -2,8 +2,11 @@ package org.sagebionetworks.bridge.schema;
 
 import static org.testng.Assert.assertEquals;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.json.DefaultObjectMapper;
 
 public class UploadSchemaKeyTest {
     @Test
@@ -64,5 +67,25 @@ public class UploadSchemaKeyTest {
         assertEquals(schemaKey.getSchemaId(), "test-schema");
         assertEquals(schemaKey.getRevision(), 42);
         assertEquals(schemaKey.toString(), "test-study-test-schema-v42");
+    }
+
+    @Test
+    public void jsonSerialize() throws Exception {
+        // start with JSON
+        String jsonText = "{\n" +
+                "   \"studyId\":\"test-study\",\n" +
+                "   \"schemaId\":\"test-schema\",\n" +
+                "   \"revision\":42\n" +
+                "}";
+
+        // convert to POJO
+        UploadSchemaKey schemaKey = DefaultObjectMapper.INSTANCE.readValue(jsonText, UploadSchemaKey.class);
+        assertEquals(schemaKey.toString(), "test-study-test-schema-v42");
+
+        // convert back to JSON
+        JsonNode jsonNode = DefaultObjectMapper.INSTANCE.convertValue(schemaKey, JsonNode.class);
+        assertEquals(jsonNode.get("studyId").textValue(), "test-study");
+        assertEquals(jsonNode.get("schemaId").textValue(), "test-schema");
+        assertEquals(jsonNode.get("revision").intValue(), 42);
     }
 }


### PR DESCRIPTION
Changes:
- Added a downloadS3File() to S3Helper.
- Added String constants for Upload Schema field types. This is String constants instead of a proper enum to maintain back-compat with Bridge-UDD and Bridge-EX 1.0. Updating this to an enum will be part of the UploadSchema refactor to pull in code from BridgePF.
- Made UploadSchemaKey JSON serializable.

Testing done:
- added unit tests
- gradle check (unit tests, findbugs)
- works with Bridge-EX 2.0
