### PR TITLE
add new test helper classes to be used to mock out Redis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 group = 'org.sagebionetworks'
 ext.name = 'bridge-base'
-version = '1.0'
+version = '1.1'
 
 /*** Java ***/
 

--- a/src/main/java/org/sagebionetworks/bridge/redis/InMemoryJedisOps.java
+++ b/src/main/java/org/sagebionetworks/bridge/redis/InMemoryJedisOps.java
@@ -1,0 +1,128 @@
+package org.sagebionetworks.bridge.redis;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * In-memory mock implementation of Jedis. Uses a map to store everything doesn't actually honor TTL or expiration
+ * times.
+ */
+public class InMemoryJedisOps extends JedisOps {
+    private final Map<String, String> map = new HashMap<>();
+
+    public InMemoryJedisOps() {
+        // We're mocking out everything, so we don't care about the parent constructor. The super() call is only here
+        // because javac requires it.
+        super(null);
+    }
+
+    @Override
+    public Long expire(String key, int seconds) {
+        if (seconds <= 0) {
+            map.remove(key);
+        }
+        return 1L;
+    }
+
+    @Override
+    public String setex(String key, int seconds, String value) {
+        // Contrary to what the parent class documentation says, this does NOT return the value set, but rather "OK"
+        map.put(key, value);
+        return "OK";
+    }
+
+    @Override
+    public Long setnx(String key, String value) {
+        if (map.containsKey(key)) {
+            return 0L;
+        } else {
+            map.put(key, value);
+            return 1L;
+        }
+    }
+
+    @Override
+    public String get(String key) {
+        return map.get(key);
+    }
+
+    @Override
+    public Long del(String... keyVarargs) {
+        for (String oneKey : keyVarargs) {
+            map.remove(oneKey);
+        }
+        return (long) keyVarargs.length;
+    }
+
+    @Override
+    public Long ttl(String key) {
+        if (map.containsKey(key)) {
+            // We don't honor TTLs. Just return 1;
+            return 1L;
+        } else {
+            return 0L;
+        }
+    }
+
+    private long getAsLong(String key) {
+        // The expected behavior is to treat null values as zero.
+        String str = map.get(key);
+        if (str == null) {
+            return 0;
+        } else {
+            return Long.parseLong(str);
+        }
+    }
+
+    @Override
+    public Long incr(String key) {
+        long oldValue = getAsLong(key);
+        long newValue = oldValue + 1;
+        map.put(key, Long.toString(newValue));
+        return newValue;
+    }
+
+    @Override
+    public Long decr(String key) {
+        long oldValue = getAsLong(key);
+        long newValue = oldValue - 1;
+        map.put(key, Long.toString(newValue));
+        return newValue;
+    }
+
+    @Override
+    public Long zadd(String key, double score, String member) {
+        // not used by BridgePF
+        throw new UnsupportedOperationException("Unsupported operation zadd()");
+    }
+
+    @Override
+    public Set<String> zrangeByScore(String key, Double min, Double max) {
+        // not used by BridgePF
+        throw new UnsupportedOperationException("Unsupported operation zrangeByScore()");
+    }
+
+    @Override
+    public Long zrank(String key, String member) {
+        // not used by BridgePF
+        throw new UnsupportedOperationException("Unsupported operation zrank()");
+    }
+
+    @Override
+    public Double zscore(String key, String member) {
+        // not used by BridgePF
+        throw new UnsupportedOperationException("Unsupported operation zscore()");
+    }
+
+    @Override
+    public Long zrem(String key, String... members) {
+        // not used by BridgePF
+        throw new UnsupportedOperationException("Unsupported operation zrem()");
+    }
+
+    @Override
+    public JedisTransaction getTransaction(String... keys) {
+        return new InMemoryJedisTransaction(this);
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/redis/InMemoryJedisTransaction.java
+++ b/src/main/java/org/sagebionetworks/bridge/redis/InMemoryJedisTransaction.java
@@ -1,0 +1,63 @@
+package org.sagebionetworks.bridge.redis;
+
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import redis.clients.jedis.Jedis;
+
+/**
+ * In-memory mock implementation of a JedisTransaction. Wraps around an InMemoryJedisOps. Doesn't actually honor
+ * transactionality.
+ */
+public class InMemoryJedisTransaction extends JedisTransaction {
+    private final InMemoryJedisOps ops;
+    private int numOps = 0;
+
+    public InMemoryJedisTransaction(InMemoryJedisOps ops) {
+        // We need to pass in *something*, otherwise this causes a NullPointerException. However, we don't care what it
+        // is, so just pass in a Mockito mock.
+        super(mock(Jedis.class));
+        this.ops = ops;
+    }
+
+    @Override
+    public JedisTransaction setex(String key, int seconds, String value) {
+        ops.setex(key, seconds, value);
+        numOps++;
+        return this;
+    }
+
+    @Override
+    public JedisTransaction expire(String key, int seconds) {
+        ops.expire(key, seconds);
+        numOps++;
+        return this;
+    }
+
+    @Override public JedisTransaction del(String key) {
+        ops.del(key);
+        numOps++;
+        return this;
+    }
+
+    @Override
+    public List<Object> exec() {
+        // no-op, since we don't support transactionality
+        List<Object> resultList = new ArrayList<>();
+        for (int i = 0; i < numOps; i++) {
+            resultList.add("OK");
+        }
+        return resultList;
+    }
+
+    @Override public String discard() {
+        // no-op, since we don't support transactionality
+        return "OK";
+    }
+
+    @Override public void close() {
+        // no-op, since we don't suport transactionality
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/runnable/FailableRunnable.java
+++ b/src/main/java/org/sagebionetworks/bridge/runnable/FailableRunnable.java
@@ -1,0 +1,16 @@
+package org.sagebionetworks.bridge.runnable;
+
+/**
+ * <p>
+ * Runnable doesn't allow checked exceptions. However, for test code, it's sometimes useful to have a "runnable" that
+ * can throw any exception.
+ * </p>
+ * <p>
+ * To make this Java 8 lambda compatible, do not add any other methods to this interface.
+ * </p>
+ */
+@FunctionalInterface
+public interface FailableRunnable {
+    /** Arbitrary test code. Consumers should implement this. */
+    void run() throws Exception;
+}


### PR DESCRIPTION
The Jedis classes are used in tests in BridgePF to mock out Redis. Adding them here so that they can be used in other projects.

Similarly, the FailableRunnable interface seems generally useful for tests.

Bumping the version to 1.1, since Play doesn't work with snapshot versions.
