### PR TITLE
Heartbeat Logger, help with logs for sparse services

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>bridge-base</artifactId>
-    <version>1.4</version>
+    <version>1.5</version>
 
     <properties>
         <aws.version>1.10.56</aws.version>

--- a/src/main/java/org/sagebionetworks/bridge/heartbeat/HeartbeatLogger.java
+++ b/src/main/java/org/sagebionetworks/bridge/heartbeat/HeartbeatLogger.java
@@ -1,0 +1,24 @@
+package org.sagebionetworks.bridge.heartbeat;
+
+import java.util.concurrent.TimeUnit;
+
+import com.jcabi.aspects.ScheduleWithFixedDelay;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Heartbeat logger. Used to write something to the logs every 30 minutes to ensure you have logs for every hour.
+ * Generally useful for logging utilities that assume there will be a log message every hour. Uses Jcabi.
+ *
+ * 30 minutes chosen to ensure there's at least 1 log (generally 2), while 60 minutes might cause a log at 1:59 and
+ * 3:01 if there's severe clock skew.
+ */
+@ScheduleWithFixedDelay(delay = 30, unit = TimeUnit.MINUTES)
+public class HeartbeatLogger implements Runnable {
+    private static final Logger LOG = LoggerFactory.getLogger(HeartbeatLogger.class);
+
+    @Override
+    public void run() {
+        LOG.info("Logging heartbeat...");
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/heartbeat/HeartbeatLogger.java
+++ b/src/main/java/org/sagebionetworks/bridge/heartbeat/HeartbeatLogger.java
@@ -1,24 +1,50 @@
 package org.sagebionetworks.bridge.heartbeat;
 
-import java.util.concurrent.TimeUnit;
-
-import com.jcabi.aspects.ScheduleWithFixedDelay;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Heartbeat logger. Used to write something to the logs every 30 minutes to ensure you have logs for every hour.
- * Generally useful for logging utilities that assume there will be a log message every hour. Uses Jcabi.
- *
- * 30 minutes chosen to ensure there's at least 1 log (generally 2), while 60 minutes might cause a log at 1:59 and
- * 3:01 if there's severe clock skew.
+ * Heartbeat logger. Used to write something to the logs on a regular interval to ensure you have logs for every hour.
+ * Generally useful for logging utilities that assume there will be a log message every hour.
  */
-@ScheduleWithFixedDelay(delay = 30, unit = TimeUnit.MINUTES)
 public class HeartbeatLogger implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(HeartbeatLogger.class);
 
+    private int intervalMillis;
+
+    /** Sets the heartbeat interval in minutes. */
+    public final void setIntervalMinutes(int intervalMinutes) {
+        // convert this internally to milliseconds
+        this.intervalMillis = intervalMinutes * 60000;
+    }
+
+    /**
+     * Runs the heartbeat logger. This is an infinite loop that waits the interval and logs the heartbeat message.
+     * First heartbeat message happens immediately.
+     */
     @Override
     public void run() {
+        while (shouldKeepRunning()) {
+            logHeartbeat();
+
+            if (intervalMillis > 0) {
+                try {
+                    Thread.sleep(intervalMillis);
+                } catch (InterruptedException ex) {
+                    LOG.warn("Interrupted while sleeping: " + ex.getMessage(), ex);
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+    }
+
+    /** Helper method, used for tests to verify logging was called. */
+    void logHeartbeat() {
         LOG.info("Logging heartbeat...");
+    }
+
+    /** True if the heartbeat logger should keep running. Overridden by tests to allow tests to exit. */
+    boolean shouldKeepRunning() {
+        return true;
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/heartbeat/HeartbeatLoggerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/heartbeat/HeartbeatLoggerTest.java
@@ -1,0 +1,27 @@
+package org.sagebionetworks.bridge.heartbeat;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.testng.annotations.Test;
+
+public class HeartbeatLoggerTest {
+    @Test
+    public void test() {
+        HeartbeatLogger heartbeatLogger = spy(new HeartbeatLogger());
+
+        // set interval to 0 for tests
+        heartbeatLogger.setIntervalMinutes(0);
+
+        // spy shouldKeepRunning() to run for 3 iterations
+        doReturn(true).doReturn(true).doReturn(true).doReturn(false).when(heartbeatLogger).shouldKeepRunning();
+
+        // execute
+        heartbeatLogger.run();
+
+        // verify we logged 3 times
+        verify(heartbeatLogger, times(3)).logHeartbeat();
+    }
+}


### PR DESCRIPTION
Some log tools (like Sumo Logic) scan the logs regularly and bad things happen (such as exponential backoff) happen if there are no logs. This heartbeat logger allows us to write a regular log message to ensure we have logs every hour.

Testing done:
- unit tests
- tested this through BridgeEX and BridgeUDD
