### PR TITLE
add custom DateTime serializers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,12 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>bridge-base</artifactId>
-    <version>2.1</version>
+    <version>2.2</version>
 
     <properties>
         <aws.version>1.10.56</aws.version>
         <bouncy.castle.version>1.52</bouncy.castle.version>
+        <jackson.version>2.7.4</jackson.version>
         <java.version>1.8</java.version>
         <logback.version>1.1.6</logback.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -31,6 +32,21 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sqs</artifactId>
             <version>${aws.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/src/main/java/org/sagebionetworks/bridge/json/DateTimeDeserializer.java
+++ b/src/main/java/org/sagebionetworks/bridge/json/DateTimeDeserializer.java
@@ -1,0 +1,21 @@
+package org.sagebionetworks.bridge.json;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import org.joda.time.DateTime;
+
+/**
+ * Custom deserializer for Joda DateTime. The deserializer in jackson-datatype-joda doesn't work, and the Joda Module
+ * ignores time zone.
+ */
+public class DateTimeDeserializer extends JsonDeserializer<DateTime> {
+    /** {@inheritDoc} */
+    @Override
+    public DateTime deserialize(JsonParser jp, DeserializationContext dc) throws IOException {
+        String date = jp.getText();
+        return DateTime.parse(date);
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/json/DateTimeToStringSerializer.java
+++ b/src/main/java/org/sagebionetworks/bridge/json/DateTimeToStringSerializer.java
@@ -1,0 +1,18 @@
+package org.sagebionetworks.bridge.json;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.joda.time.DateTime;
+import org.joda.time.format.ISODateTimeFormat;
+
+/** Custom serializer for Joda DateTime, because the one in jackson-datatype-joda serializes epoch milliseconds. */
+public class DateTimeToStringSerializer extends JsonSerializer<DateTime> {
+    /** {@inheritDoc} */
+    @Override
+    public void serialize(DateTime dateTime, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+        jgen.writeString(dateTime.toString(ISODateTimeFormat.dateTime()));
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/json/DateTimeDeserializerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/json/DateTimeDeserializerTest.java
@@ -1,0 +1,25 @@
+package org.sagebionetworks.bridge.json;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import com.fasterxml.jackson.core.JsonParser;
+import org.joda.time.DateTime;
+import org.testng.annotations.Test;
+
+public class DateTimeDeserializerTest {
+    private static final String DATE_TIME_STRING = "2016-05-09T15:33:09.376-0700";
+    private static final DateTime DATE_TIME = DateTime.parse(DATE_TIME_STRING);
+
+    @Test
+    public void test() throws Exception {
+        // mock JsonParser
+        JsonParser mockJP = mock(JsonParser.class);
+        when(mockJP.getText()).thenReturn(DATE_TIME_STRING);
+
+        // execute and validate
+        DateTime result = new DateTimeDeserializer().deserialize(mockJP, null);
+        assertEquals(result, DATE_TIME);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/json/DateTimeToStringSerializerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/json/DateTimeToStringSerializerTest.java
@@ -1,0 +1,26 @@
+package org.sagebionetworks.bridge.json;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import org.joda.time.DateTime;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.Test;
+
+public class DateTimeToStringSerializerTest {
+    private static final DateTime DATE_TIME = DateTime.parse("2016-05-09T15:33:09.376-0700");
+
+    @Test
+    public void test() throws Exception {
+        // mock JsonGenerator
+        JsonGenerator mockJGen = mock(JsonGenerator.class);
+
+        // execute and validate
+        new DateTimeToStringSerializer().serialize(DATE_TIME, mockJGen, null);
+        ArgumentCaptor<String> arg = ArgumentCaptor.forClass(String.class);
+        verify(mockJGen).writeString(arg.capture());
+        assertEquals(DateTime.parse(arg.getValue()), DATE_TIME);
+    }
+}


### PR DESCRIPTION
Because the ones in jackson-datatype-joda are very underwhelming.

Testing done:
- added unit tests
- mvn verify (findbugs, jacoco coverage)
- installed locally and used these in Bridge-EX to verify behavior
