### PR TITLE
add util for sanitizing schema field names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,4 @@
 language: java
 jdk: oraclejdk8
 sudo: false
-script: mvn clean verify
-deploy:
-  provider: script
-  script: mvn deploy
-  on:
-    branch: release
+script: mvn clean deploy

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>bridge-base</artifactId>
-    <version>2.2</version>
+    <version>2.3</version>
 
     <properties>
         <aws.version>1.10.56</aws.version>

--- a/src/main/java/org/sagebionetworks/bridge/schema/SchemaUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/schema/SchemaUtils.java
@@ -1,0 +1,46 @@
+package org.sagebionetworks.bridge.schema;
+
+import java.util.regex.Pattern;
+
+/** Static utility class for Upload Schemas. */
+public class SchemaUtils {
+    private static final Pattern FIELD_NAME_DOT_REPLACEMENT_PATTERN = Pattern.compile("\\.{2,}");
+    private static final Pattern FIELD_NAME_END_REPLACEMENT_PATTERN = Pattern.compile("[\\s\\.]$");
+    private static final Pattern FIELD_NAME_INVALID_CHAR_REPLACEMENT_PATTERN = Pattern.compile("[^\\w\\-\\. ]");
+    private static final Pattern FIELD_NAME_START_REPLACEMENT_PATTERN = Pattern.compile("^[\\s\\-\\.]");
+
+    /**
+     * <p>
+     * Synapse column names have a few notable restrictions:
+     * 1. Can't start with dash (-).
+     * 2. Can't start or end with period (.), nor can you have two periods in a row.
+     * 3. Field names are always trimmed.
+     * 4. Only a specific set of characters are allowed. For simplicity, only accept alphanumeric chars, dashes (-),
+     * periods (.), underscores (_), and spaces.
+     * </p>
+     * <p>
+     * This method takes in a raw field name and runs it throgh the above rules and returns the sanitized field name.
+     * This can be used for schema field names as well as multiple-choice values (which will be used for Synapse
+     * column names, and hence the above rules apply).
+     * </p>
+     *
+     * @param name
+     *         field name to be sanitized
+     * @return sanitized field name
+     */
+    public static String sanitizeFieldName(String name) {
+        // If the first char is an invalid char (space, dash, dot), replace it with a _
+        name = FIELD_NAME_START_REPLACEMENT_PATTERN.matcher(name).replaceFirst("_");
+
+        // Similarly, if the last char is an in invalid char (space, dot, but not dash).
+        name = FIELD_NAME_END_REPLACEMENT_PATTERN.matcher(name).replaceFirst("_");
+
+        // Replace consecutive dots with a single dot.
+        name = FIELD_NAME_DOT_REPLACEMENT_PATTERN.matcher(name).replaceAll(".");
+
+        // Replace invalid chars with _
+        name = FIELD_NAME_INVALID_CHAR_REPLACEMENT_PATTERN.matcher(name).replaceAll("_");
+
+        return name;
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/schema/SchemaUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/schema/SchemaUtilsTest.java
@@ -1,0 +1,28 @@
+package org.sagebionetworks.bridge.schema;
+
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class SchemaUtilsTest {
+    @DataProvider(name = "sanitizeFieldNameDataProvider")
+    public Object[][] sanitizeFieldNameDataProvider() {
+        return new Object[][] {
+                { "Passthrough1", "Passthrough1" },
+                { "__lots__of__underscores__", "__lots__of__underscores__" },
+                { "--lots--of--dashes--", "_-lots--of--dashes--" },
+                { "..lots..of..dots..", "_.lots.of.dots._" },
+                { "  lots  of  spaces  ", "_ lots  of  spaces _" },
+                { "- .mix- .of- .chars- .", "_ .mix- .of- .chars- _" },
+                { "!@replaces#$invalid%^chars&*", "__replaces__invalid__chars__" },
+                { "replace\tnewlines\nand\rtabs", "replace_newlines_and_tabs" },
+        };
+    }
+
+    @Test(dataProvider = "sanitizeFieldNameDataProvider")
+    public void testSanitizeFieldName(String input, String expected) {
+        String output = SchemaUtils.sanitizeFieldName(input);
+        assertEquals(output, expected);
+    }
+}


### PR DESCRIPTION
Add a util class for sanitizing schema field names. This is to be used in Bridge Server for field names and multi-choice answer enumeration as well as in BridgeEX to canonicalize submitted multi-choice answers.

This also includes a change to the Travis build script to build and release directly from the master branch instead of the release branch.
