### PR TITLE
add null-check to SchemaUtils.sanitizeFieldName()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>bridge-base</artifactId>
-    <version>2.3</version>
+    <version>2.4</version>
 
     <properties>
         <aws.version>1.10.56</aws.version>

--- a/src/main/java/org/sagebionetworks/bridge/schema/SchemaUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/schema/SchemaUtils.java
@@ -2,6 +2,8 @@ package org.sagebionetworks.bridge.schema;
 
 import java.util.regex.Pattern;
 
+import com.google.common.base.Strings;
+
 /** Static utility class for Upload Schemas. */
 public class SchemaUtils {
     private static final Pattern FIELD_NAME_DOT_REPLACEMENT_PATTERN = Pattern.compile("\\.{2,}");
@@ -26,9 +28,13 @@ public class SchemaUtils {
      *
      * @param name
      *         field name to be sanitized
-     * @return sanitized field name
+     * @return sanitized field name, or null if the input was null
      */
     public static String sanitizeFieldName(String name) {
+        if (Strings.isNullOrEmpty(name)) {
+            return name;
+        }
+
         // If the first char is an invalid char (space, dash, dot), replace it with a _
         name = FIELD_NAME_START_REPLACEMENT_PATTERN.matcher(name).replaceFirst("_");
 

--- a/src/test/java/org/sagebionetworks/bridge/schema/SchemaUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/schema/SchemaUtilsTest.java
@@ -9,6 +9,9 @@ public class SchemaUtilsTest {
     @DataProvider(name = "sanitizeFieldNameDataProvider")
     public Object[][] sanitizeFieldNameDataProvider() {
         return new Object[][] {
+                { null, null },
+                { "", "" },
+                { "    ", "_  _" },
                 { "Passthrough1", "Passthrough1" },
                 { "__lots__of__underscores__", "__lots__of__underscores__" },
                 { "--lots--of--dashes--", "_-lots--of--dashes--" },


### PR DESCRIPTION
Forgot null-check. Adding it in now. (The alternative is to not have the null-check and force all callers to check for null. This alternative is not compatible with our current approach to input validation in BridgePF.)
