### PR TITLE
squelch "bad requests" in PollSqsWorker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>bridge-base</artifactId>
-    <version>2.4</version>
+    <version>2.5</version>
 
     <properties>
         <aws.version>1.10.56</aws.version>
@@ -184,6 +184,7 @@
                         <exclude>org/sagebionetworks/bridge/dynamodb/*Exception.class</exclude>
                         <exclude>org/sagebionetworks/bridge/lock/*Exception.class</exclude>
                         <exclude>org/sagebionetworks/bridge/redis/*Exception.class</exclude>
+                        <exclude>org/sagebionetworks/bridge/sqs/*Exception.class</exclude>
 
                         <!-- The following classes except specifically because they are untestable -->
                         <exclude>org/sagebionetworks/bridge/dynamodb/DynamoQueryHelper.class</exclude>

--- a/src/main/java/org/sagebionetworks/bridge/sqs/PollSqsCallback.java
+++ b/src/main/java/org/sagebionetworks/bridge/sqs/PollSqsCallback.java
@@ -8,7 +8,8 @@ public interface PollSqsCallback {
     /**
      * Processes the SQS message. The PollSqsWorker assumes that if this returns normally, then the SQS message was
      * successfully processed and should be deleted to prevent duplicate processing. If this throws, the PollSqsWorker
-     * does not delete the message, so the message will be re-processed.
+     * does not delete the message (unless it's a PollSqsWorkerBadRequestException), so the message will be
+     * re-processed.
      *
      * @param messageBody
      *         the raw SQS message body

--- a/src/main/java/org/sagebionetworks/bridge/sqs/PollSqsWorker.java
+++ b/src/main/java/org/sagebionetworks/bridge/sqs/PollSqsWorker.java
@@ -60,7 +60,12 @@ public class PollSqsWorker implements Runnable {
                     continue;
                 }
 
-                callback.callback(sqsMessage.getBody());
+                try {
+                    callback.callback(sqsMessage.getBody());
+                } catch (PollSqsWorkerBadRequestException ex) {
+                    // This is a bad request. It should not be retried. Log a warning and suppress.
+                    LOG.warn("PollSqsWorker bad request: " + ex.getMessage(), ex);
+                }
 
                 // If the callback doesn't throw, this means it's successfully processed the message, and we should
                 // delete it from SQS to prevent re-processing the message.

--- a/src/main/java/org/sagebionetworks/bridge/sqs/PollSqsWorkerBadRequestException.java
+++ b/src/main/java/org/sagebionetworks/bridge/sqs/PollSqsWorkerBadRequestException.java
@@ -1,0 +1,23 @@
+package org.sagebionetworks.bridge.sqs;
+
+/**
+ * Exception to signal to the PollSqsWorker that this request deterministically fails and should not be retried. (More
+ * specifically, we should suppress the exception and still delete the SQS message.
+ */
+@SuppressWarnings("serial")
+public class PollSqsWorkerBadRequestException extends Exception {
+    public PollSqsWorkerBadRequestException() {
+    }
+
+    public PollSqsWorkerBadRequestException(String message) {
+        super(message);
+    }
+
+    public PollSqsWorkerBadRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public PollSqsWorkerBadRequestException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
Add the concept of "bad request" to PollSqsWorker. These are requests that will fail, but the PollSqsWorker shouldn't retry these requests and should delete the message from SQS so the request doesn't re-cycle. This includes things like malformed requests or account not found.

Testing done:
- mvn verify (unit tests, findbugs, jacoco coverage reports)
- integrated this with BridgeUDD to test a real use case for this

See also
https://github.com/Sage-Bionetworks/BridgeUserDataDownloadService/pull/14
https://sagebionetworks.jira.com/browse/BRIDGE-1398
