### PR TITLE
Fix connection leak in S3Helper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>bridge-base</artifactId>
-    <version>2.5</version>
+    <version>2.6</version>
 
     <properties>
         <aws.version>1.10.56</aws.version>

--- a/src/main/java/org/sagebionetworks/bridge/s3/S3Helper.java
+++ b/src/main/java/org/sagebionetworks/bridge/s3/S3Helper.java
@@ -86,8 +86,7 @@ public class S3Helper {
     @RetryOnFailure(attempts = 5, delay = 100, unit = TimeUnit.MILLISECONDS, types = AmazonClientException.class,
             randomize = false)
     public byte[] readS3FileAsBytes(String bucket, String key) throws IOException {
-        S3Object s3File = s3Client.getObject(bucket, key);
-        try (InputStream s3Stream = s3File.getObjectContent()) {
+        try (S3Object s3File = s3Client.getObject(bucket, key); InputStream s3Stream = s3File.getObjectContent()) {
             return ByteStreams.toByteArray(s3Stream);
         }
     }
@@ -106,9 +105,8 @@ public class S3Helper {
     @RetryOnFailure(attempts = 5, delay = 100, unit = TimeUnit.MILLISECONDS, types = AmazonClientException.class,
             randomize = false)
     public List<String> readS3FileAsLines(String bucket, String key) throws IOException {
-        S3Object s3File = s3Client.getObject(bucket, key);
-        try (BufferedReader recordIdReader = new BufferedReader(new InputStreamReader(s3File.getObjectContent(),
-                Charsets.UTF_8))) {
+        try (S3Object s3File = s3Client.getObject(bucket, key); BufferedReader recordIdReader = new BufferedReader(
+                new InputStreamReader(s3File.getObjectContent(), Charsets.UTF_8))) {
             return CharStreams.readLines(recordIdReader);
         }
     }


### PR DESCRIPTION
When we call S3Client.getObject() for a streaming (non-file) use, we need to close the S3Object afterwards. This minor change moves the instantiation inside the try-with-resources so we can properly close the S3Object.

This may or may not be related to BridgeEX connection timeouts, but it's worth fixing this regardless.

Testing done:
- updated unit tests
- mvn verify (unit tests, findbugs, jacoco test coverage)
- integrated with BridgeEX and tested redriving record IDs from an S3 file
