### PR TITLE
add FileHelper.fileSize()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>bridge-base</artifactId>
-    <version>2.7.2</version>
+    <version>2.7.3</version>
 
     <properties>
         <aws.version>1.10.56</aws.version>

--- a/src/main/java/org/sagebionetworks/bridge/file/FileHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/file/FileHelper.java
@@ -86,6 +86,14 @@ public class FileHelper {
     }
 
     /**
+     * Gets the file size in bytes. Should only be used for files, not for directories. This is because our mock file
+     * system tracks directories and files separately (to make it easier to mock and test).
+     */
+    public long fileSize(File file) {
+        return file.length();
+    }
+
+    /**
      * Non-static move method. Should only be used for files and not directories. This is because our mock file system
      * tracks directories and files separately (to make it easier to mock and test).
      */


### PR DESCRIPTION
This is needed to filter out empty attachments from BridgeEX.

Testing done:
* mvn verify passes
* tested through BridgeEX