### PR TITLE
AnnotationBasedTableCreator to allow multiple indices using the same range key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>bridge-base</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.4</version>
 
     <properties>
         <aws.version>1.10.56</aws.version>

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/AnnotationBasedTableCreatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/AnnotationBasedTableCreatorTest.java
@@ -1,0 +1,70 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndexDescription;
+import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
+import com.amazonaws.services.dynamodbv2.model.TableDescription;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.dynamodb.test.GlobalIndexTest;
+
+public class AnnotationBasedTableCreatorTest {
+    @Test
+    public void testGlobalIndices() {
+        // Our test class is GlobalIndexTest, which has a bunch of contrived indices.
+        List<TableDescription> tableDescList = DynamoTestUtils.MAPPER.getTables(GlobalIndexTest.class);
+        assertEquals(tableDescList.size(), 1);
+
+        TableDescription tableDesc = tableDescList.get(0);
+        assertTrue(tableDesc.getTableName().endsWith("GlobalIndexTest"));
+
+        // There are 7 indices, though due to how Reflection works, we can't be sure what order they'll be in.
+        // Convert to a map so we can validate each index.
+        List<GlobalSecondaryIndexDescription> globalIndexDescList = tableDesc.getGlobalSecondaryIndexes();
+        assertEquals(globalIndexDescList.size(), 7);
+
+        Map<String, GlobalSecondaryIndexDescription> indexDescByName = globalIndexDescList.stream()
+                .collect(Collectors.toMap(GlobalSecondaryIndexDescription::getIndexName, index -> index));
+        assertEquals(indexDescByName.size(), 7);
+
+        // index with hash key and no range key
+        validateGlobalIndexDesc(indexDescByName.get("hash-without-range-index"), "hashWithoutRangeHashKey", null);
+
+        // index with non-list annotations
+        validateGlobalIndexDesc(indexDescByName.get("simple-index"), "simpleIndexHashKey", "simpleIndexRangeKey");
+
+        // indices with list annotations (a, b) * (x, y) = (ax, ay, bx, by)
+        validateGlobalIndexDesc(indexDescByName.get("ax-list-index"), "listIndexHashKeyA", "listIndexRangeKeyX");
+        validateGlobalIndexDesc(indexDescByName.get("ay-list-index"), "listIndexHashKeyA", "listIndexRangeKeyY");
+        validateGlobalIndexDesc(indexDescByName.get("bx-list-index"), "listIndexHashKeyB", "listIndexRangeKeyX");
+        validateGlobalIndexDesc(indexDescByName.get("by-list-index"), "listIndexHashKeyB", "listIndexRangeKeyY");
+
+        // index with list annotation with hash key only
+        validateGlobalIndexDesc(indexDescByName.get("a-only-list-index"), "listIndexHashKeyA", null);
+    }
+
+    private static void validateGlobalIndexDesc(GlobalSecondaryIndexDescription indexDesc, String hashKey,
+            String rangeKey) {
+        List<KeySchemaElement> keySchemaList = indexDesc.getKeySchema();
+
+        // There's always a hash key.
+        assertEquals(keySchemaList.get(0).getAttributeName(), hashKey);
+        assertEquals(keySchemaList.get(0).getKeyType(), "HASH");
+
+        if (rangeKey == null) {
+            // No range key. Key schema list has 1 element.
+            assertEquals(keySchemaList.size(), 1);
+        } else {
+            // Yes range key. Key schema list has 2 elements. Validate the range key.
+            assertEquals(keySchemaList.size(), 2);
+            assertEquals(keySchemaList.get(1).getAttributeName(), rangeKey);
+            assertEquals(keySchemaList.get(1).getKeyType(), "RANGE");
+        }
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoTableMapperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoTableMapperTest.java
@@ -25,7 +25,6 @@ public class DynamoTableMapperTest {
     public void testGetAnnotatedTables() {
         List<TableDescription> tables = DynamoTestUtils.MAPPER.getTables(DynamoTestUtils.PACKAGE);
         assertNotNull(tables);
-        assertEquals(2, tables.size());
         Map<String, TableDescription> tableMap = new HashMap<String, TableDescription>();
         for (TableDescription table : tables) {
             tableMap.put(table.getTableName(), table);
@@ -46,7 +45,6 @@ public class DynamoTableMapperTest {
     public void testLoadDynamoTableClasses() {
         List<Class<?>> classes = DynamoTestUtils.MAPPER.loadDynamoTableClasses(DynamoTestUtils.PACKAGE);
         assertNotNull(classes);
-        assertEquals(2, classes.size());
         Set<String> classSet = new HashSet<String>();
         for (Class<?> clazz : classes) {
             classSet.add(clazz.getName());
@@ -76,7 +74,7 @@ public class DynamoTableMapperTest {
     public void createsGlobalIndices() {
         List<TableDescription> tables = DynamoTestUtils.MAPPER.getTables(TestTask.class);
         TableDescription table = DynamoTestUtils.getTableByName(tables, "TestTask");
-        assertEquals(3, table.getGlobalSecondaryIndexes().size());
+        assertEquals(2, table.getGlobalSecondaryIndexes().size());
 
         GlobalSecondaryIndexDescription index = findIndex(table.getGlobalSecondaryIndexes(), "guid-index");
         assertEquals("INCLUDE", index.getProjection().getProjectionType());
@@ -90,9 +88,6 @@ public class DynamoTableMapperTest {
         assertEquals("scheduledOn", index.getKeySchema().get(1).getAttributeName());
         assertEquals(Long.valueOf(18), index.getProvisionedThroughput().getWriteCapacityUnits());
         assertEquals(Long.valueOf(20), index.getProvisionedThroughput().getReadCapacityUnits());
-
-        index = findIndex(table.getGlobalSecondaryIndexes(), "healthCode-expiresOn-index");
-        assertEquals("expiresOn", index.getKeySchema().get(0).getAttributeName());
     }
 
     private GlobalSecondaryIndexDescription findIndex(List<GlobalSecondaryIndexDescription> list, String name) {

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/test/GlobalIndexTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/test/GlobalIndexTest.java
@@ -1,0 +1,56 @@
+package org.sagebionetworks.bridge.dynamodb.test;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexRangeKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+
+// Contrived test class for use with AnnotationBasedTableCreatorTest. We only care about method annotations, so the
+// methods all return null.
+@DynamoDBTable(tableName = "GlobalIndexTest")
+public class GlobalIndexTest {
+    @DynamoDBHashKey
+    public String getTableHashKey() {
+        return null;
+    }
+
+    @DynamoDBIndexHashKey(attributeName = "hashWithoutRangeHashKey",
+            globalSecondaryIndexName = "hash-without-range-index")
+    public String getHashWithoutRangeHashKey() {
+        return null;
+    }
+
+    @DynamoDBIndexHashKey(attributeName = "simpleIndexHashKey", globalSecondaryIndexName = "simple-index")
+    public String getSimpleIndexHashKey() {
+        return null;
+    }
+
+    @DynamoDBIndexRangeKey(attributeName = "simpleIndexRangeKey", globalSecondaryIndexName = "simple-index")
+    public String getSimpleIndexRangeKey() {
+        return null;
+    }
+
+    @DynamoDBIndexHashKey(attributeName = "listIndexHashKeyA",
+            globalSecondaryIndexNames = { "ax-list-index", "ay-list-index", "a-only-list-index" })
+    public String getListIndexHashKeyA() {
+        return null;
+    }
+
+    @DynamoDBIndexHashKey(attributeName = "listIndexHashKeyB",
+            globalSecondaryIndexNames = { "bx-list-index", "by-list-index" })
+    public String getListIndexHashKeyB() {
+        return null;
+    }
+
+    @DynamoDBIndexRangeKey(attributeName = "listIndexRangeKeyX",
+            globalSecondaryIndexNames = { "ax-list-index", "bx-list-index" })
+    public String getListIndexRangeKeyX() {
+        return null;
+    }
+
+    @DynamoDBIndexRangeKey(attributeName = "listIndexRangeKeyY",
+            globalSecondaryIndexNames = { "ay-list-index", "by-list-index" })
+    public String getListIndexRangeKeyY() {
+        return null;
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/test/TestTask.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/test/TestTask.java
@@ -55,7 +55,6 @@ public class TestTask {
     public void setScheduledOn(Long scheduledOn) {
         this.scheduledOn = scheduledOn;
     }
-    @DynamoDBIndexRangeKey(attributeName = "expiresOn", globalSecondaryIndexName = "healthCode-expiresOn-index")
     @DynamoDBAttribute
     public Long getExpiresOn() {
         return expiresOn;


### PR DESCRIPTION
There's a bug in AnnotationBasedTableCreator which only looks at the single index name field in the DynamoDBIndexHashKey/RangeKey annotations instead of the list field. This prevents us from having multiple indices using the same fields, and causes a hard crash on startup when provisioning new DDB tables.

This change fixes that bug and also cleans up the logic.

Testing done:
* mvn verify (unit tests, jacoco test coverage, findbugs)
* pulled into BridgePF and created tables in a clean namespace; verified a sample of indices

This is pulled into BridgePF in https://github.com/Sage-Bionetworks/BridgePF/pull/1371