### PR TITLE
Case insensitive check for Bridge environment

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/config/PropertiesConfig.java
+++ b/src/main/java/org/sagebionetworks/bridge/config/PropertiesConfig.java
@@ -227,7 +227,7 @@ public class PropertiesConfig implements Config {
             return DEFAULT_ENV;
         }
         for (Environment env : Environment.values()) {
-            if (env.name().toLowerCase().equals(envName)) {
+            if (env.name().toLowerCase().equals(envName.toLowerCase())) {
                 return env;
             }
         }


### PR DESCRIPTION
Setting "BridgeEnv=DEV" environment variable does not work due to
case sensitive check[1]. This change will allow setting BridgeEnv
to "dev" or "DEV". The use case for this is to allow setting
"BridgeEnv=DEV" in BridgePF-infra as an EB env var and reuse the
BridgeEnv variable to set the bucket names to "DEV_CONSENTS_BUCKET".

[1] https://gist.github.com/anonymous/7f7cf706b0249f0fdb50ba696c18dcd2