### PR TITLE
BRIDGE-1989: Fix overriding Bridge properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>bridge-base</artifactId>
-    <version>2.7.6</version>
+    <version>2.7.7</version>
 
     <properties>
         <aws.version>1.10.56</aws.version>

--- a/src/main/java/org/sagebionetworks/bridge/config/PropertiesConfig.java
+++ b/src/main/java/org/sagebionetworks/bridge/config/PropertiesConfig.java
@@ -24,7 +24,6 @@ import org.springframework.core.io.support.PropertiesLoaderUtils;
  * Config backed by Java properties.
  */
 public class PropertiesConfig implements Config {
-
     /**
      * Default user when user is not specified in the config.
      */
@@ -276,7 +275,12 @@ public class PropertiesConfig implements Config {
                 value = envReader.read(key);
             }
             if (value != null) {
-                collapsed.setProperty(key, value);
+                if (key.startsWith(envName + ".")) {
+                    String strippedName = key.substring(envName.length() + 1);
+                    collapsed.setProperty(strippedName, value);
+                } else {
+                    collapsed.setProperty(key, value);
+                }
             }
         }
         return collapsed;

--- a/src/test/java/org/sagebionetworks/bridge/config/PropertiesConfigTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/config/PropertiesConfigTest.java
@@ -179,30 +179,30 @@ public class PropertiesConfigTest {
     }
 
     @Test
-    public void testOverwriteFromString() throws IOException, URISyntaxException {
+    public void envSpecificPropertyOverwritesProperty() throws IOException, URISyntaxException {
         Path localPath = Paths.get(getClass().getClassLoader().getResource("conf/local.conf").toURI());
         System.setProperty(PropertiesConfig.ENV_KEY, "dev");
         Config config = new PropertiesConfig(TEST_CONF_FILE, localPath);
-        assertEquals(config.get("example.property"), "local.value.for.dev");
+        assertEquals("local.value.for.dev", config.get("example.property"));
     }
 
     @Test
-    public void testOverwriteEnvFromString() throws IOException, URISyntaxException {
+    public void envVariableOverwritesProperty() throws IOException, URISyntaxException {
         Path localPath = Paths.get(getClass().getClassLoader().getResource("conf/local.conf").toURI());
         System.setProperty(PropertiesConfig.ENV_KEY, "dev");
         System.setProperty("example.property", "override.value.for.dev");
         Config config = new PropertiesConfig(TEST_CONF_FILE, localPath);
-        assertEquals(config.get("example.property"), "override.value.for.dev");
+        assertEquals("override.value.for.dev", config.get("example.property"));
         System.clearProperty("example.property");
     }
 
     @Test
-    public void testOverwriteEnvSpecificFromString() throws IOException, URISyntaxException {
+    public void envVariableOverwritesEnvSpecificProperty() throws IOException, URISyntaxException {
         Path localPath = Paths.get(getClass().getClassLoader().getResource("conf/local.conf").toURI());
         System.setProperty(PropertiesConfig.ENV_KEY, "dev");
         System.setProperty("dev.example.property", "override.value.for.dev");
         Config config = new PropertiesConfig(TEST_CONF_FILE, localPath);
-        assertEquals(config.get("example.property"), "override.value.for.dev");
+        assertEquals("override.value.for.dev", config.get("example.property"));
         System.clearProperty("dev.example.property");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/config/PropertiesConfigTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/config/PropertiesConfigTest.java
@@ -183,6 +183,26 @@ public class PropertiesConfigTest {
         Path localPath = Paths.get(getClass().getClassLoader().getResource("conf/local.conf").toURI());
         System.setProperty(PropertiesConfig.ENV_KEY, "dev");
         Config config = new PropertiesConfig(TEST_CONF_FILE, localPath);
-        assertEquals("local.value.for.dev", config.get("example.property"));
+        assertEquals(config.get("example.property"), "local.value.for.dev");
+    }
+
+    @Test
+    public void testOverwriteEnvFromString() throws IOException, URISyntaxException {
+        Path localPath = Paths.get(getClass().getClassLoader().getResource("conf/local.conf").toURI());
+        System.setProperty(PropertiesConfig.ENV_KEY, "dev");
+        System.setProperty("example.property", "override.value.for.dev");
+        Config config = new PropertiesConfig(TEST_CONF_FILE, localPath);
+        assertEquals(config.get("example.property"), "override.value.for.dev");
+        System.clearProperty("example.property");
+    }
+
+    @Test
+    public void testOverwriteEnvSpecificFromString() throws IOException, URISyntaxException {
+        Path localPath = Paths.get(getClass().getClassLoader().getResource("conf/local.conf").toURI());
+        System.setProperty(PropertiesConfig.ENV_KEY, "dev");
+        System.setProperty("dev.example.property", "override.value.for.dev");
+        Config config = new PropertiesConfig(TEST_CONF_FILE, localPath);
+        assertEquals(config.get("example.property"), "override.value.for.dev");
+        System.clearProperty("dev.example.property");
     }
 }


### PR DESCRIPTION
The method to overwrite property values was ignoring environment
values prepended with the BridgeEnv key.