### PR TITLE
move SynapseHelper methods from Exporter to bridge-base; add ThrowingConsumer functional interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>bridge-base</artifactId>
-    <version>2.7.7</version>
+    <version>2.7.8</version>
 
     <properties>
         <aws.version>1.10.56</aws.version>
@@ -99,6 +99,11 @@
             <version>${bouncy.castle.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.sagebionetworks</groupId>
+            <artifactId>synapseJavaClient</artifactId>
+            <version>206.0</version>
+        </dependency>
+        <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
             <version>2.8.0</version>
@@ -136,6 +141,14 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <repositories>
+        <repository>
+            <id>sagebionetworks-libs-releases-local</id>
+            <name>sagebionetworks-libs-releases-local</name>
+            <url>http://sagebionetworks.artifactoryonline.com/sagebionetworks/libs-releases-local</url>
+        </repository>
+    </repositories>
 
     <build>
         <plugins>
@@ -185,6 +198,7 @@
                 <configuration>
                     <excludes>
                         <!-- no point in testing exceptions, since they are entirely boilerplate code -->
+                        <exclude>org/sagebionetworks/bridge/exceptions/*</exclude>
                         <exclude>org/sagebionetworks/bridge/config/*Exception.class</exclude>
                         <exclude>org/sagebionetworks/bridge/dynamodb/*Exception.class</exclude>
                         <exclude>org/sagebionetworks/bridge/lock/*Exception.class</exclude>
@@ -207,7 +221,7 @@
                                 <limit>
                                     <counter>BRANCH</counter>
                                     <value>COVEREDRATIO</value>
-                                    <minimum>0.70</minimum>
+                                    <minimum>0.75</minimum>
                                 </limit>
                             </limits>
                         </rule>

--- a/src/main/java/org/sagebionetworks/bridge/exceptions/BridgeSynapseException.java
+++ b/src/main/java/org/sagebionetworks/bridge/exceptions/BridgeSynapseException.java
@@ -1,0 +1,20 @@
+package org.sagebionetworks.bridge.exceptions;
+
+/** Exception in Bridge calling Synapse, that's not a SynapseException. */
+@SuppressWarnings("serial")
+public class BridgeSynapseException extends Exception {
+    public BridgeSynapseException() {
+    }
+
+    public BridgeSynapseException(String message) {
+        super(message);
+    }
+
+    public BridgeSynapseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public BridgeSynapseException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/exceptions/BridgeSynapseNonRetryableException.java
+++ b/src/main/java/org/sagebionetworks/bridge/exceptions/BridgeSynapseNonRetryableException.java
@@ -1,0 +1,20 @@
+package org.sagebionetworks.bridge.exceptions;
+
+/** A BridgeSynapseException that is a deterministic failure and should not be retried. */
+@SuppressWarnings("serial")
+public class BridgeSynapseNonRetryableException extends BridgeSynapseException {
+    public BridgeSynapseNonRetryableException() {
+    }
+
+    public BridgeSynapseNonRetryableException(String message) {
+        super(message);
+    }
+
+    public BridgeSynapseNonRetryableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public BridgeSynapseNonRetryableException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/synapse/SynapseHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/synapse/SynapseHelper.java
@@ -1,0 +1,690 @@
+package org.sagebionetworks.bridge.synapse;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import com.amazonaws.AmazonClientException;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.RateLimiter;
+import com.jcabi.aspects.RetryOnFailure;
+import org.sagebionetworks.client.SynapseClient;
+import org.sagebionetworks.client.exceptions.SynapseException;
+import org.sagebionetworks.client.exceptions.SynapseResultNotReadyException;
+import org.sagebionetworks.repo.model.ACCESS_TYPE;
+import org.sagebionetworks.repo.model.AccessControlList;
+import org.sagebionetworks.repo.model.ResourceAccess;
+import org.sagebionetworks.repo.model.file.FileHandle;
+import org.sagebionetworks.repo.model.table.ColumnChange;
+import org.sagebionetworks.repo.model.table.ColumnModel;
+import org.sagebionetworks.repo.model.table.ColumnType;
+import org.sagebionetworks.repo.model.table.CsvTableDescriptor;
+import org.sagebionetworks.repo.model.table.TableEntity;
+import org.sagebionetworks.repo.model.table.TableSchemaChangeRequest;
+import org.sagebionetworks.repo.model.table.TableSchemaChangeResponse;
+import org.sagebionetworks.repo.model.table.TableUpdateRequest;
+import org.sagebionetworks.repo.model.table.TableUpdateResponse;
+import org.sagebionetworks.repo.model.table.UploadToTableResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.sagebionetworks.bridge.exceptions.BridgeSynapseException;
+import org.sagebionetworks.bridge.exceptions.BridgeSynapseNonRetryableException;
+
+/** Synapse operations that are common across multiple workers and should be shared. */
+public class SynapseHelper {
+    private static final Logger LOG = LoggerFactory.getLogger(SynapseHelper.class);
+
+    private static final Joiner COMMA_SPACE_JOINER = Joiner.on(", ").useForNull("");
+
+    // Package-scoped for unit tests.
+    static final Set<ACCESS_TYPE> ACCESS_TYPE_ALL = ImmutableSet.copyOf(ACCESS_TYPE.values());
+    static final Set<ACCESS_TYPE> ACCESS_TYPE_READ = ImmutableSet.of(ACCESS_TYPE.READ, ACCESS_TYPE.DOWNLOAD);
+
+    // Map of allowed column type changes. Key is the old type. Value is the new type.
+    //
+    // A few notes: This is largely based on whether the data can be converted in Synapse tables. Since booleans are
+    // stored as 0/1 and dates are stored as epoch milliseconds, converting these to strings means old values will be
+    // numeric types, but new values are likely to be "true"/"false" or ISO8601 timestamps. This leads to more
+    // confusion overall, so we've decided to block it.
+    //
+    // Similarly, if you convert a bool to a numeric type (int, float), Synapse will convert the bools to 0s and 1s.
+    // However, old bools in DynamoDB are still using "true"/"false", which will no longer serialize to Synapse. To
+    // prevent this data loss, we're also not allowing bools to convert to numeric types.
+    //
+    // Also note that due to a bug, we cannot currently convert anything to a LargeText.
+    // See https://sagebionetworks.jira.com/browse/PLFM-4028
+    private static final SetMultimap<ColumnType, ColumnType> ALLOWED_OLD_TYPE_TO_NEW_TYPE =
+            ImmutableSetMultimap.<ColumnType, ColumnType>builder()
+                    // Numeric types can changed to types with more precision (int to float), but not less
+                    // precision (float to int).
+                    .put(ColumnType.INTEGER, ColumnType.DOUBLE)
+                    // Date can be converted to int and float (epoch milliseconds), and can be converted back from an
+                    // int. However, we block converting from float, since that causes data loss.
+                    .put(ColumnType.DATE, ColumnType.INTEGER)
+                    .put(ColumnType.DATE, ColumnType.DOUBLE)
+                    .put(ColumnType.INTEGER, ColumnType.DATE)
+                    // Numeric types are trivially converted to strings.
+                    .put(ColumnType.DOUBLE, ColumnType.STRING)
+                    .put(ColumnType.INTEGER, ColumnType.STRING)
+                    .build();
+
+    /**
+     * The max lengths of various Synapse column types. This is used to determine how long a Synapse column can be
+     * when we convert the column to a String. This only contains column types that can be converted to Strings. Note
+     * that it excludes dates and bools, as Synapse considers these numeric types, but Bridge uses ISO8601 and
+     * "true"/"false".
+     */
+    private static final Map<ColumnType, Integer> SYNAPSE_TYPE_TO_MAX_LENGTH =
+            ImmutableMap.<ColumnType, Integer>builder()
+                    // Empirically, the longest float in Synapse is 22 chars long
+                    .put(ColumnType.DOUBLE, 22)
+                    // Synapse uses a bigint (signed long), which can be 20 chars long
+                    .put(ColumnType.INTEGER, 20)
+                    .build();
+
+    private int asyncIntervalMillis = 1000;
+    private int asyncTimeoutLoops = 300;
+    private SynapseClient synapseClient;
+
+    // Rate limiter, used to limit the amount of traffic to Synapse. Synapse throttles at 10 requests per second.
+    private final RateLimiter rateLimiter = RateLimiter.create(10.0);
+
+    // Rate limiter for getColumnModelsForEntity(). Empirically, Synapse throttles at 24 requests per minute. Add a
+    // safety factor and rate limit to 12 per minute.
+    private final RateLimiter getColumnModelsRateLimiter = RateLimiter.create(12.0 / 60.0);
+
+    /** Set the number of milliseconds between loops while polling async requests in Synapse. Defaults to 1000. */
+    public final void setAsyncIntervalMillis(int asyncIntervalMillis) {
+        this.asyncIntervalMillis = asyncIntervalMillis;
+    }
+
+    /**
+     * Sets the number of loops while polling async requests in Synapse before we time out the request. Default is 300
+     * (5 minutes, using the default async interval millis).
+     */
+    public final void setAsyncTimeoutLoops(int asyncTimeoutLoops) {
+        this.asyncTimeoutLoops = asyncTimeoutLoops;
+    }
+
+    /**
+     * Set the rate limiting for general traffic to Synapse. Generally used for testing or to tweak rate limits
+     * without a code change. Values are per second. Default is 10.0.
+     */
+    public final void setRateLimit(double rateLimit) {
+        rateLimiter.setRate(rateLimit);
+    }
+
+    /**
+     * Set the rate limiting for getColumnModels. Generally used for testing or to tweak rate limits without a code
+     * change. Values are per second. Default is 0.2 (12 per minute).
+     */
+    public final void setGetColumnModelsRateLimit(double rateLimit) {
+        getColumnModelsRateLimiter.setRate(rateLimit);
+    }
+
+    /** Synapse client. */
+    public final void setSynapseClient(SynapseClient synapseClient) {
+        this.synapseClient = synapseClient;
+    }
+
+    /**
+     * Helper method to create a table with the specified columns and set up ACLs. The data access team is set with
+     * read permissions and the principal ID is set with all permissions.
+     *
+     * @param columnList
+     *         list of column models to create on the table
+     * @param dataAccessTeamId
+     *         data access team ID, set with read permissions
+     * @param principalId
+     *         principal ID, set with all permissions
+     * @param projectId
+     *         Synapse project to create the table in
+     * @param tableName
+     *         table name
+     * @return Synapse table ID
+     * @throws BridgeSynapseException
+     *         under unexpected circumstances, like a table created with the wrong number of columns
+     * @throws SynapseException
+     *         if the underlying Synapse calls fail
+     */
+    public String createTableWithColumnsAndAcls(List<ColumnModel> columnList, long dataAccessTeamId,
+            long principalId, String projectId, String tableName) throws BridgeSynapseException, SynapseException {
+        // Create columns
+        List<ColumnModel> createdColumnList = createColumnModelsWithRetry(columnList);
+        if (columnList.size() != createdColumnList.size()) {
+            throw new BridgeSynapseException("Error creating Synapse table " + tableName + ": Tried to create " +
+                    columnList.size() + " columns. Actual: " + createdColumnList.size() + " columns.");
+        }
+
+        List<String> columnIdList = new ArrayList<>();
+        //noinspection Convert2streamapi
+        for (ColumnModel oneCreatedColumn : createdColumnList) {
+            columnIdList.add(oneCreatedColumn.getId());
+        }
+
+        // create table
+        TableEntity synapseTable = new TableEntity();
+        synapseTable.setName(tableName);
+        synapseTable.setParentId(projectId);
+        synapseTable.setColumnIds(columnIdList);
+        TableEntity createdTable = createTableWithRetry(synapseTable);
+        String synapseTableId = createdTable.getId();
+
+        // create ACLs
+        // ResourceAccess is a mutable object, but the Synapse API takes them in a Set. This is a little weird.
+        // IMPORTANT: Do not modify ResourceAccess objects after adding them to the set. This will break the set.
+        Set<ResourceAccess> resourceAccessSet = new HashSet<>();
+
+        ResourceAccess exporterOwnerAccess = new ResourceAccess();
+        exporterOwnerAccess.setPrincipalId(principalId);
+        exporterOwnerAccess.setAccessType(ACCESS_TYPE_ALL);
+        resourceAccessSet.add(exporterOwnerAccess);
+
+        ResourceAccess dataAccessTeamAccess = new ResourceAccess();
+        dataAccessTeamAccess.setPrincipalId(dataAccessTeamId);
+        dataAccessTeamAccess.setAccessType(ACCESS_TYPE_READ);
+        resourceAccessSet.add(dataAccessTeamAccess);
+
+        AccessControlList acl = new AccessControlList();
+        acl.setId(synapseTableId);
+        acl.setResourceAccess(resourceAccessSet);
+        createAclWithRetry(acl);
+
+        return synapseTableId;
+    }
+
+    /**
+     * Returns true if the old column can be converted to the new column in a meaningful way without data loss. Used to
+     * determine if the schema changes, whether Bridge should try to modify the table.
+     *
+     * @param oldColumn
+     *         column model currently in Synapse
+     * @param newColumn
+     *         column model we want to replace it with
+     * @return true if they're compatible, false otherwise
+     * @throws BridgeSynapseException
+     *         if there's an unexpected error comparing the columns
+     */
+    public static boolean isCompatibleColumn(ColumnModel oldColumn, ColumnModel newColumn)
+            throws BridgeSynapseException {
+        // Ignore the following attributes:
+        // ID - The ones from Synapse will have IDs, but the ones we generate from the schema won't. This is normal.
+        // defaultValues, enumValues - We don't use these, and changing these won't affect data integrity.
+
+        // If types are different, check the table.
+        if (oldColumn.getColumnType() != newColumn.getColumnType()) {
+            Set<ColumnType> allowedNewTypes = ALLOWED_OLD_TYPE_TO_NEW_TYPE.get(oldColumn.getColumnType());
+            if (!allowedNewTypes.contains(newColumn.getColumnType())) {
+                return false;
+            }
+        }
+
+        // For string types, check max length. You can increase the max length, but you can't decrease it.
+        if (newColumn.getColumnType() == ColumnType.STRING &&
+                !Objects.equals(oldColumn.getMaximumSize(), newColumn.getMaximumSize())) {
+            long oldMaxLength;
+            if (oldColumn.getMaximumSize() != null) {
+                // If the old field def specified a max length, just use it.
+                oldMaxLength = oldColumn.getMaximumSize();
+            } else if (SYNAPSE_TYPE_TO_MAX_LENGTH.containsKey(oldColumn.getColumnType())) {
+                // The max length of the old field type is specified by its type.
+                oldMaxLength = SYNAPSE_TYPE_TO_MAX_LENGTH.get(oldColumn.getColumnType());
+            } else {
+                // This should never happen. If we get here, that means we somehow have a String column in Synapse
+                // without a Max Length parameter. Abort and throw.
+                throw new BridgeSynapseNonRetryableException("old column " + oldColumn.getName() + " has type " +
+                        oldColumn.getColumnType() + " and no max length");
+            }
+
+            if (newColumn.getMaximumSize() == null) {
+                // This should also never happen. This means that we generated a String column without a Max Length,
+                // which is bad.
+                throw new BridgeSynapseNonRetryableException("new column " + newColumn.getName() + " has type " +
+                        "STRING and no max length");
+            }
+            long newMaxLength = newColumn.getMaximumSize();
+
+            // You can't decrease max length.
+            if (newMaxLength < oldMaxLength) {
+                return false;
+            }
+        }
+
+        // This should never happen, but if the names are somehow different, they aren't compatible.
+        if (!Objects.equals(oldColumn.getName(), newColumn.getName())) {
+            return false;
+        }
+
+        // If we passed all incompatibility checks, then we're compatible.
+        return true;
+    }
+
+    /**
+     * Helper method to detect when a schema changes and updates the Synapse table accordingly. Will reject schema
+     * changes that delete or modify columns. Optimized so if no columns were inserted, it won't modify the table.
+     *
+     * @param synapseTableId
+     *         table to update
+     * @param newColumnList
+     *         columns to update the table with
+     * @throws BridgeSynapseException
+     *         if the column changes are incompatible
+     * @throws SynapseException
+     *         if the underlying Synapse calls fail
+     */
+    public void safeUpdateTable(String synapseTableId, List<ColumnModel> newColumnList) throws BridgeSynapseException,
+            SynapseException {
+        // Get existing columns from table.
+        List<ColumnModel> existingColumnList = getColumnModelsForTableWithRetry(synapseTableId);
+
+        // Compute the columns that were added, deleted, and kept.
+        Map<String, ColumnModel> existingColumnsByName = Maps.uniqueIndex(existingColumnList, ColumnModel::getName);
+        Map<String, ColumnModel> newColumnsByName = Maps.uniqueIndex(newColumnList, ColumnModel::getName);
+
+        Set<String> addedColumnNameSet = Sets.difference(newColumnsByName.keySet(), existingColumnsByName.keySet());
+        Set<String> deletedColumnNameSet = Sets.difference(existingColumnsByName.keySet(), newColumnsByName.keySet());
+        Set<String> keptColumnNameSet = Sets.intersection(existingColumnsByName.keySet(), newColumnsByName.keySet());
+
+        // Were columns deleted? If so, log an error and shortcut. (Don't modify the table.)
+        boolean shouldThrow = false;
+        if (!deletedColumnNameSet.isEmpty()) {
+            LOG.error("Table " + synapseTableId + " has deleted columns: " + COMMA_SPACE_JOINER.join(
+                    deletedColumnNameSet));
+            shouldThrow = true;
+        }
+
+        // Similarly, were any columns changed?
+        Set<String> modifiedColumnNameSet = new HashSet<>();
+        Set<String> incompatibleColumnNameSet = new HashSet<>();
+        for (String oneKeptColumnName : keptColumnNameSet) {
+            // Was this column modified? Check type and max length, since those are the only fields we care about. We
+            // can't use .equals(), because newly generated columns don't have IDs.
+            ColumnModel existingColumn = existingColumnsByName.get(oneKeptColumnName);
+            ColumnModel newColumn = newColumnsByName.get(oneKeptColumnName);
+            if (existingColumn.getColumnType() != newColumn.getColumnType() ||
+                    !Objects.equals(existingColumn.getMaximumSize(), newColumn.getMaximumSize())) {
+                modifiedColumnNameSet.add(oneKeptColumnName);
+            } else {
+                continue;
+            }
+
+            // This column was modified. Was the modification compatible?
+            if (!isCompatibleColumn(existingColumn, newColumn)) {
+                incompatibleColumnNameSet.add(oneKeptColumnName);
+            }
+        }
+        if (!incompatibleColumnNameSet.isEmpty()) {
+            LOG.error("Table " + synapseTableId + " has incompatible modified columns: " + COMMA_SPACE_JOINER.join(
+                    incompatibleColumnNameSet));
+            shouldThrow = true;
+        }
+
+        if (shouldThrow) {
+            throw new BridgeSynapseNonRetryableException("Table has deleted and/or modified columns");
+        }
+
+        // Optimization: Were any columns added or modified?
+        if (addedColumnNameSet.isEmpty() && modifiedColumnNameSet.isEmpty()) {
+            return;
+        }
+
+        // Make sure the columns have been created / get column IDs.
+        List<ColumnModel> createdColumnList = createColumnModelsWithRetry(newColumnList);
+
+        // Create list of column changes.
+        List<ColumnChange> columnChangeList = new ArrayList<>();
+        List<String> colIdList = new ArrayList<>();
+        for (ColumnModel oneCreatedColumn : createdColumnList) {
+            ColumnModel existingColumn = existingColumnsByName.get(oneCreatedColumn.getName());
+            String createdColumnId = oneCreatedColumn.getId();
+            String existingColumnId = existingColumn != null ? existingColumn.getId() : null;
+
+            // Only add column change if the column is different.
+            if (!Objects.equals(createdColumnId, existingColumnId)) {
+                ColumnChange columnChange = new ColumnChange();
+                columnChange.setOldColumnId(existingColumnId);
+                columnChange.setNewColumnId(createdColumnId);
+                columnChangeList.add(columnChange);
+            }
+
+            // Want to specify order of columns.
+            colIdList.add(createdColumnId);
+        }
+
+        // Create schema change request.
+        TableSchemaChangeRequest schemaChangeRequest = new TableSchemaChangeRequest();
+        schemaChangeRequest.setEntityId(synapseTableId);
+        schemaChangeRequest.setChanges(columnChangeList);
+        schemaChangeRequest.setOrderedColumnIds(colIdList);
+
+        // Update table.
+        updateTableColumns(schemaChangeRequest, synapseTableId);
+    }
+
+    /**
+     * Updates table columns.
+     *
+     * @param schemaChangeRequest
+     *         requested change
+     * @param tableId
+     *         table to update
+     * @return table change response
+     * @throws BridgeSynapseException
+     *         if there's a general error with Bridge
+     * @throws SynapseException
+     *         if there's an error calling Synapse
+     */
+    public TableSchemaChangeResponse updateTableColumns(TableSchemaChangeRequest schemaChangeRequest, String tableId)
+            throws BridgeSynapseException, SynapseException {
+        // For convenience, this API only contains a single TableSchemaChangeRequest, but the Synapse API takes a whole
+        // list. Wrap it in a list.
+        List<TableUpdateRequest> changeList = ImmutableList.of(schemaChangeRequest);
+
+        // Start the table update job.
+        String jobToken = startTableTransactionWithRetry(changeList, tableId);
+
+        // Poll async get until success or timeout.
+        boolean success = false;
+        List<TableUpdateResponse> responseList = null;
+        for (int loops = 0; loops < asyncTimeoutLoops; loops++) {
+            if (asyncIntervalMillis > 0) {
+                try {
+                    Thread.sleep(asyncIntervalMillis);
+                } catch (InterruptedException ex) {
+                    // noop
+                }
+            }
+
+            // poll
+            responseList = getTableTransactionResultWithRetry(jobToken, tableId);
+            if (responseList != null) {
+                success = true;
+                break;
+            }
+
+            // Result not ready. Loop around again.
+        }
+
+        if (!success) {
+            throw new BridgeSynapseException("Timed out updating table columns for table " + tableId);
+        }
+
+        // The list should have a single response, and it should be a TableSchemaChangeResponse.
+        if (responseList.size() != 1) {
+            throw new BridgeSynapseException("Expected one table update response for table " + tableId + ", but got " +
+                    responseList.size());
+        }
+        TableUpdateResponse singleResponse = responseList.get(0);
+        if (!(singleResponse instanceof TableSchemaChangeResponse)) {
+            throw new BridgeSynapseException("Expected a TableSchemaChangeResponse for table " + tableId +
+                    ", but got " + singleResponse.getClass().getName());
+        }
+
+        return (TableSchemaChangeResponse) singleResponse;
+    }
+
+    /**
+     * Takes a TSV file from disk and uploads and applies its rows to a Synapse table.
+     *
+     * @param tableId
+     *         Synapse table ID to upload the TSV to
+     * @param file
+     *         TSV file to apply to the table
+     * @return number of rows processed
+     * @throws BridgeSynapseException
+     *         if there's a general error calling Synapse
+     * @throws IOException
+     *         if there's an error uploading the file handle
+     * @throws SynapseException
+     *         if there's an error calling Synapse
+     */
+    public long uploadTsvFileToTable(String tableId, File file) throws BridgeSynapseException,
+            IOException, SynapseException {
+        // Upload TSV as a file handle.
+        FileHandle tableFileHandle = createFileHandleWithRetry(file);
+        String fileHandleId = tableFileHandle.getId();
+
+        // start tsv import
+        CsvTableDescriptor tableDesc = new CsvTableDescriptor();
+        tableDesc.setIsFirstLineHeader(true);
+        tableDesc.setSeparator("\t");
+        String jobToken = uploadTsvStartWithRetry(tableId, fileHandleId, tableDesc);
+
+        // poll asyncGet until success or timeout
+        boolean success = false;
+        Long linesProcessed = null;
+        for (int loops = 0; loops < asyncTimeoutLoops; loops++) {
+            if (asyncIntervalMillis > 0) {
+                try {
+                    Thread.sleep(asyncIntervalMillis);
+                } catch (InterruptedException ex) {
+                    // noop
+                }
+            }
+
+            // poll
+            UploadToTableResult uploadResult = getUploadTsvStatus(jobToken, tableId);
+            if (uploadResult != null) {
+                linesProcessed = uploadResult.getRowsProcessed();
+                success = true;
+                break;
+            }
+
+            // Result not ready. Loop around again.
+        }
+
+        if (!success) {
+            throw new BridgeSynapseException("Timed out uploading file handle " + fileHandleId);
+        }
+        if (linesProcessed == null) {
+            // Not sure if Synapse will ever do this, but code defensively, just in case.
+            throw new BridgeSynapseException("Null rows processed");
+        }
+
+        return linesProcessed;
+    }
+
+    /**
+     * Creates an ACL in Synapse. This is a retry wrapper.
+     *
+     * @param acl
+     *         ACL to create
+     * @return created ACL
+     * @throws SynapseException
+     *         if the call fails
+     */
+    @RetryOnFailure(attempts = 2, delay = 100, unit = TimeUnit.MILLISECONDS, types = SynapseException.class,
+            randomize = false)
+    public AccessControlList createAclWithRetry(AccessControlList acl) throws SynapseException {
+        rateLimiter.acquire();
+        return synapseClient.createACL(acl);
+    }
+
+    /**
+     * Creates column models in Synapse. This is a retry wrapper.
+     *
+     * @param columnList
+     *         list of column models to create
+     * @return created column models
+     * @throws SynapseException
+     *         if the call fails
+     */
+    @RetryOnFailure(attempts = 2, delay = 100, unit = TimeUnit.MILLISECONDS, types = SynapseException.class,
+            randomize = false)
+    public List<ColumnModel> createColumnModelsWithRetry(List<ColumnModel> columnList) throws SynapseException {
+        rateLimiter.acquire();
+        return synapseClient.createColumnModels(columnList);
+    }
+
+    /**
+     * Uploads a file to Synapse as a file handle. This is a retry wrapper.
+     *
+     * @param file
+     *         file to upload
+     * @return file handle object from Synapse
+     * @throws IOException
+     *         if reading the file from disk fails
+     * @throws SynapseException
+     *         if the Synapse call fails
+     */
+    @RetryOnFailure(attempts = 2, delay = 1, unit = TimeUnit.SECONDS,
+            types = { AmazonClientException.class, SynapseException.class }, randomize = false)
+    @SuppressWarnings("UnusedParameters")
+    public FileHandle createFileHandleWithRetry(File file) throws IOException, SynapseException {
+        rateLimiter.acquire();
+        return synapseClient.multipartUpload(file, null, null, null);
+    }
+
+    /**
+     * Create table in Synapse. This is a retry wrapper.
+     *
+     * @param table
+     *         table to create
+     * @return created table
+     * @throws SynapseException
+     *         if the Synapse call fails
+     */
+    @RetryOnFailure(attempts = 2, delay = 100, unit = TimeUnit.MILLISECONDS, types = SynapseException.class,
+            randomize = false)
+    public TableEntity createTableWithRetry(TableEntity table) throws SynapseException {
+        rateLimiter.acquire();
+        return synapseClient.createEntity(table);
+    }
+
+    /**
+     * Get the column models for a Synapse table. This is a retry wrapper.
+     *
+     * @param tableId
+     *         table to get column info for
+     * @return list of columns
+     * @throws SynapseException
+     *         if the call fails
+     */
+    @RetryOnFailure(attempts = 2, delay = 100, unit = TimeUnit.MILLISECONDS, types = SynapseException.class,
+            randomize = false)
+    public List<ColumnModel> getColumnModelsForTableWithRetry(String tableId) throws SynapseException {
+        getColumnModelsRateLimiter.acquire();
+        return synapseClient.getColumnModelsForTableEntity(tableId);
+    }
+
+    /**
+     * Gets a Synapse table. This is a retry wrapper.
+     *
+     * @param tableId
+     *         table to get
+     * @return table
+     * @throws SynapseException
+     *         if the Synapse call fails
+     */
+    @RetryOnFailure(attempts = 2, delay = 100, unit = TimeUnit.MILLISECONDS, types = SynapseException.class,
+            randomize = false)
+    public TableEntity getTableWithRetry(String tableId) throws SynapseException {
+        rateLimiter.acquire();
+        return synapseClient.getEntity(tableId, TableEntity.class);
+    }
+
+    /**
+     * Starts a Synapse table transaction (for example, a schema update request). This is a retry wrapper.
+     *
+     * @param changeList
+     *         changes to apply to table
+     * @param tableId
+     *         table to be changed
+     * @return async job token
+     * @throws SynapseException
+     *         if the Synapse call fails
+     */
+    @RetryOnFailure(attempts = 2, delay = 100, unit = TimeUnit.MILLISECONDS, types = SynapseException.class,
+            randomize = false)
+    public String startTableTransactionWithRetry(List<TableUpdateRequest> changeList, String tableId)
+            throws SynapseException {
+        rateLimiter.acquire();
+        return synapseClient.startTableTransactionJob(changeList, tableId);
+    }
+
+    /**
+     * Polls Synapse to get the job status for a table transaction (such as a schema update request). If the job is not
+     * ready, this will return null instead of throwing a SynapseResultNotReadyException. This is to prevent spurious
+     * retries when a SynapseResultNotReadyException is thrown. This is a retry wrapper.
+     *
+     * @param jobToken
+     *         job token from startTableTransactionWithRetry()
+     * @param tableId
+     *         table the job was working on
+     * @return response from the table update
+     * @throws SynapseException
+     *         if the job fails
+     */
+    @RetryOnFailure(attempts = 2, delay = 100, unit = TimeUnit.MILLISECONDS, types = SynapseException.class,
+            randomize = false)
+    public List<TableUpdateResponse> getTableTransactionResultWithRetry(String jobToken, String tableId)
+            throws SynapseException {
+        try {
+            rateLimiter.acquire();
+            return synapseClient.getTableTransactionJobResults(jobToken, tableId);
+        } catch (SynapseResultNotReadyException ex) {
+            // catch this and return null so we don't retry on "not ready"
+            return null;
+        }
+    }
+
+    /**
+     * Starts applying an uploaded TSV file handle to a Synapse table. This is a retry wrapper.
+     *
+     * @param tableId
+     *         the table to apply the TSV to
+     * @param fileHandleId
+     *         the TSV file handle
+     * @param tableDescriptor
+     *         TSV table descriptor
+     * @return an async job token
+     * @throws SynapseException
+     *         if the Synapse call fails
+     */
+    @RetryOnFailure(attempts = 2, delay = 100, unit = TimeUnit.MILLISECONDS, types = SynapseException.class,
+            randomize = false)
+    public String uploadTsvStartWithRetry(String tableId, String fileHandleId, CsvTableDescriptor tableDescriptor)
+            throws SynapseException {
+        rateLimiter.acquire();
+        return synapseClient.uploadCsvToTableAsyncStart(tableId, fileHandleId, null, null, tableDescriptor, null);
+    }
+
+    /**
+     * Polls Synapse to get the job status for the upload TSV to table job. If the job is not ready, this will return
+     * null instead of throwing a SynapseResultNotReadyException. This is to prevent spurious retries when a
+     * SynapseResultNotReadyException is thrown. This is a retry wrapper.
+     *
+     * @param jobToken
+     *         job token from uploadTsvStartWithRetry()
+     * @param tableId
+     *         table the job was working on
+     * @return upload table result object
+     * @throws SynapseException
+     *         if the job fails
+     */
+    @RetryOnFailure(attempts = 2, delay = 100, unit = TimeUnit.MILLISECONDS, types = SynapseException.class,
+            randomize = false)
+    public UploadToTableResult getUploadTsvStatus(String jobToken, String tableId) throws SynapseException {
+        try {
+            rateLimiter.acquire();
+            return synapseClient.uploadCsvToTableAsyncGet(jobToken, tableId);
+        } catch (SynapseResultNotReadyException ex) {
+            // catch this and return null so we don't retry on "not ready"
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/worker/ThrowingConsumer.java
+++ b/src/main/java/org/sagebionetworks/bridge/worker/ThrowingConsumer.java
@@ -1,0 +1,11 @@
+package org.sagebionetworks.bridge.worker;
+
+/**
+ * Functional interface that consumes a single argument, returns no values, and can throw exceptions. This is generally
+ * used by the Bridge Worker Platform, and subprojects can just implement this interface.
+ */
+@FunctionalInterface
+public interface ThrowingConsumer<T> {
+    /** Accepts the value of the given type and performs processing as needed. */
+    void accept(T t) throws Exception;
+}

--- a/src/test/java/org/sagebionetworks/bridge/synapse/SynapseHelperSafeUpdateTableTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/synapse/SynapseHelperSafeUpdateTableTest.java
@@ -1,0 +1,213 @@
+package org.sagebionetworks.bridge.synapse;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import org.mockito.ArgumentCaptor;
+import org.sagebionetworks.repo.model.table.ColumnChange;
+import org.sagebionetworks.repo.model.table.ColumnModel;
+import org.sagebionetworks.repo.model.table.ColumnType;
+import org.sagebionetworks.repo.model.table.TableSchemaChangeRequest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.exceptions.BridgeSynapseNonRetryableException;
+
+public class SynapseHelperSafeUpdateTableTest {
+    private static final String SYNAPSE_TABLE_ID = "dummy-synapse-table-id";
+
+    private SynapseHelper synapseHelper;
+
+    @BeforeMethod
+    public void before() throws Exception {
+        // Spy SynapseHelper. This way, we can test the logic in SynapseHelper without being tightly coupled to the
+        // implementations of get column, create column, or update table.
+        // Spied methods return null as a placeholder. If tests need to return specific values, that test needs to set
+        // up the mock.
+        synapseHelper = spy(new SynapseHelper());
+        doReturn(null).when(synapseHelper).createColumnModelsWithRetry(any());
+        doReturn(null).when(synapseHelper).updateTableColumns(any(), any());
+
+        // Create the "old column list" that we work with.
+        List<ColumnModel> oldColumnList = ImmutableList.of(makeColumn("foo", "foo-id"),
+                makeColumn("bar", "bar-id"));
+        doReturn(oldColumnList).when(synapseHelper).getColumnModelsForTableWithRetry(SYNAPSE_TABLE_ID);
+    }
+
+    @Test(expectedExceptions = BridgeSynapseNonRetryableException.class, expectedExceptionsMessageRegExp =
+            "Table has deleted and/or modified columns")
+    public void rejectDelete() throws Exception {
+        // New column is missing "foo".
+        List<ColumnModel> newColumnList = ImmutableList.of(makeColumn("bar", null));
+        synapseHelper.safeUpdateTable(SYNAPSE_TABLE_ID, newColumnList);
+    }
+
+    @Test(expectedExceptions = BridgeSynapseNonRetryableException.class, expectedExceptionsMessageRegExp =
+            "Table has deleted and/or modified columns")
+    public void incompatibleTypeChange() throws Exception {
+        // New column "foo" is a file handle.
+        List<ColumnModel> newColumnList = new ArrayList<>();
+
+        ColumnModel newFooColumn = new ColumnModel();
+        newFooColumn.setName("foo");
+        newFooColumn.setColumnType(ColumnType.FILEHANDLEID);
+        newColumnList.add(newFooColumn);
+
+        newColumnList.add(makeColumn("bar", null));
+
+        synapseHelper.safeUpdateTable(SYNAPSE_TABLE_ID, newColumnList);
+    }
+
+    @Test(expectedExceptions = BridgeSynapseNonRetryableException.class, expectedExceptionsMessageRegExp =
+            "Table has deleted and/or modified columns")
+    public void incompatibleLengthChange() throws Exception {
+        // New column "foo" length decreased to 24
+        List<ColumnModel> newColumnList = new ArrayList<>();
+
+        ColumnModel newFooColumn = new ColumnModel();
+        newFooColumn.setName("foo");
+        newFooColumn.setColumnType(ColumnType.STRING);
+        newFooColumn.setMaximumSize(24L);
+        newColumnList.add(newFooColumn);
+
+        newColumnList.add(makeColumn("bar", null));
+
+        synapseHelper.safeUpdateTable(SYNAPSE_TABLE_ID, newColumnList);
+    }
+
+    @Test
+    public void dontUpdateIfNoAddedOrModifiedColumns() throws Exception {
+        // Swap foo and bar. No update.
+        List<ColumnModel> newColumnList = ImmutableList.of(makeColumn("bar", null),
+                makeColumn("foo", null));
+        synapseHelper.safeUpdateTable(SYNAPSE_TABLE_ID, newColumnList);
+
+        // Verify dependent calls (or lack thereof)
+        verify(synapseHelper, never()).createColumnModelsWithRetry(any());
+        verify(synapseHelper, never()).updateTableColumns(any(), any());
+    }
+
+    @Test
+    public void addAndSwapColumns() throws Exception {
+        // Swap foo and bar, and insert baz.
+        List<ColumnModel> newColumnList = ImmutableList.of(makeColumn("bar", null),
+                makeColumn("foo", null), makeColumn("baz", null));
+
+        // We create these columns (which are the same, but have column IDs).
+        List<ColumnModel> createdColumnList = ImmutableList.of(makeColumn("bar", "bar-id"),
+                makeColumn("foo", "foo-id"), makeColumn("baz", "baz-id"));
+        doReturn(createdColumnList).when(synapseHelper).createColumnModelsWithRetry(newColumnList);
+
+        // Execute
+        synapseHelper.safeUpdateTable(SYNAPSE_TABLE_ID, newColumnList);
+
+        // We call createColumnModels() with all of the columns.
+        verify(synapseHelper).createColumnModelsWithRetry(newColumnList);
+
+        // Verify update table call.
+        ArgumentCaptor<TableSchemaChangeRequest> requestCaptor = ArgumentCaptor.forClass(
+                TableSchemaChangeRequest.class);
+        verify(synapseHelper).updateTableColumns(requestCaptor.capture(), eq(SYNAPSE_TABLE_ID));
+
+        TableSchemaChangeRequest request = requestCaptor.getValue();
+        assertEquals(request.getEntityId(), SYNAPSE_TABLE_ID);
+        assertEquals(request.getOrderedColumnIds(), ImmutableList.of("bar-id", "foo-id", "baz-id"));
+
+        List<ColumnChange> changeList = request.getChanges();
+        assertEquals(changeList.size(), 1);
+        assertNull(changeList.get(0).getOldColumnId());
+        assertEquals(changeList.get(0).getNewColumnId(), "baz-id");
+    }
+
+    @Test
+    public void compatibleTypeChange() throws Exception {
+        // Old column is an int.
+        ColumnModel oldColumn = new ColumnModel();
+        oldColumn.setName("my-col");
+        oldColumn.setId("old-col-id");
+        oldColumn.setColumnType(ColumnType.INTEGER);
+        List<ColumnModel> oldColumnList = ImmutableList.of(oldColumn);
+        doReturn(oldColumnList).when(synapseHelper).getColumnModelsForTableWithRetry(SYNAPSE_TABLE_ID);
+
+        // New column is a string.
+        List<ColumnModel> newColumnList = ImmutableList.of(makeColumn("my-col", null));
+        List<ColumnModel> createdColumnList = ImmutableList.of(makeColumn("my-col", "new-col-id"));
+        doReturn(createdColumnList).when(synapseHelper).createColumnModelsWithRetry(newColumnList);
+
+        // Execute
+        synapseHelper.safeUpdateTable(SYNAPSE_TABLE_ID, newColumnList);
+
+        // We call createColumnModels() with all of the columns.
+        verify(synapseHelper).createColumnModelsWithRetry(newColumnList);
+
+        // Verify update table call.
+        ArgumentCaptor<TableSchemaChangeRequest> requestCaptor = ArgumentCaptor.forClass(
+                TableSchemaChangeRequest.class);
+        verify(synapseHelper).updateTableColumns(requestCaptor.capture(), eq(SYNAPSE_TABLE_ID));
+
+        TableSchemaChangeRequest request = requestCaptor.getValue();
+        assertEquals(request.getEntityId(), SYNAPSE_TABLE_ID);
+        assertEquals(request.getOrderedColumnIds(), ImmutableList.of("new-col-id"));
+
+        List<ColumnChange> changeList = request.getChanges();
+        assertEquals(changeList.size(), 1);
+        assertEquals(changeList.get(0).getOldColumnId(), "old-col-id");
+        assertEquals(changeList.get(0).getNewColumnId(), "new-col-id");
+    }
+
+    @Test
+    public void compatibleLengthChange() throws Exception {
+        // Old column is a string of length 24, which will be increased to 100.
+        ColumnModel oldColumn = new ColumnModel();
+        oldColumn.setName("my-col");
+        oldColumn.setId("old-col-id");
+        oldColumn.setColumnType(ColumnType.STRING);
+        oldColumn.setMaximumSize(24L);
+        List<ColumnModel> oldColumnList = ImmutableList.of(oldColumn);
+        doReturn(oldColumnList).when(synapseHelper).getColumnModelsForTableWithRetry(SYNAPSE_TABLE_ID);
+
+        // New column is a string of length 100.
+        List<ColumnModel> newColumnList = ImmutableList.of(makeColumn("my-col", null));
+        List<ColumnModel> createdColumnList = ImmutableList.of(makeColumn("my-col", "new-col-id"));
+        doReturn(createdColumnList).when(synapseHelper).createColumnModelsWithRetry(newColumnList);
+
+        // Execute
+        synapseHelper.safeUpdateTable(SYNAPSE_TABLE_ID, newColumnList);
+
+        // We call createColumnModels() with all of the columns.
+        verify(synapseHelper).createColumnModelsWithRetry(newColumnList);
+
+        // Verify update table call.
+        ArgumentCaptor<TableSchemaChangeRequest> requestCaptor = ArgumentCaptor.forClass(
+                TableSchemaChangeRequest.class);
+        verify(synapseHelper).updateTableColumns(requestCaptor.capture(), eq(SYNAPSE_TABLE_ID));
+
+        TableSchemaChangeRequest request = requestCaptor.getValue();
+        assertEquals(request.getEntityId(), SYNAPSE_TABLE_ID);
+        assertEquals(request.getOrderedColumnIds(), ImmutableList.of("new-col-id"));
+
+        List<ColumnChange> changeList = request.getChanges();
+        assertEquals(changeList.size(), 1);
+        assertEquals(changeList.get(0).getOldColumnId(), "old-col-id");
+        assertEquals(changeList.get(0).getNewColumnId(), "new-col-id");
+    }
+
+    private static ColumnModel makeColumn(String name, String id) {
+        ColumnModel col = new ColumnModel();
+        col.setName(name);
+        col.setId(id);
+        col.setColumnType(ColumnType.STRING);
+        col.setMaximumSize(100L);
+        return col;
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/synapse/SynapseHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/synapse/SynapseHelperTest.java
@@ -1,0 +1,408 @@
+package org.sagebionetworks.bridge.synapse;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+import java.io.File;
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableList;
+import org.mockito.ArgumentCaptor;
+import org.sagebionetworks.client.SynapseClient;
+import org.sagebionetworks.client.exceptions.SynapseResultNotReadyException;
+import org.sagebionetworks.repo.model.AccessControlList;
+import org.sagebionetworks.repo.model.ResourceAccess;
+import org.sagebionetworks.repo.model.file.FileHandle;
+import org.sagebionetworks.repo.model.file.S3FileHandle;
+import org.sagebionetworks.repo.model.table.ColumnModel;
+import org.sagebionetworks.repo.model.table.ColumnType;
+import org.sagebionetworks.repo.model.table.CsvTableDescriptor;
+import org.sagebionetworks.repo.model.table.TableEntity;
+import org.sagebionetworks.repo.model.table.TableUpdateRequest;
+import org.sagebionetworks.repo.model.table.TableUpdateResponse;
+import org.sagebionetworks.repo.model.table.UploadToTableResult;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.exceptions.BridgeSynapseNonRetryableException;
+
+@SuppressWarnings("unchecked")
+public class SynapseHelperTest {
+    @Test
+    public void createTableWithColumnsAndAcls() throws Exception {
+        // Set up inputs. This table will have two columns. We pass this straight through to the create column call,
+        // and we never look inside, so don't bother actually instantiating the columns.
+        List<ColumnModel> columnList = ImmutableList.of(new ColumnModel(), new ColumnModel());
+
+        // Spy SynapseHelper. This way, we can test the logic in SynapseHelper without being tightly coupled to the
+        // implementations of create column, create table, and create ACLs.
+        SynapseHelper synapseHelper = spy(new SynapseHelper());
+
+        // mock create column call - We only care about the IDs, so don't bother instantiating the rest.
+        ColumnModel createdFooColumn = new ColumnModel();
+        createdFooColumn.setId("foo-col-id");
+
+        ColumnModel createdBarColumn = new ColumnModel();
+        createdBarColumn.setId("bar-col-id");
+
+        List<ColumnModel> createdColumnList = ImmutableList.of(createdFooColumn, createdBarColumn);
+
+        doReturn(createdColumnList).when(synapseHelper).createColumnModelsWithRetry(columnList);
+
+        // mock create table call - We only care about the table ID, so don't bother instantiating the rest.
+        TableEntity createdTable = new TableEntity();
+        createdTable.setId("test-table");
+
+        ArgumentCaptor<TableEntity> tableCaptor = ArgumentCaptor.forClass(TableEntity.class);
+        doReturn(createdTable).when(synapseHelper).createTableWithRetry(tableCaptor.capture());
+
+        // Mock create ACL call. Even though we don't care about the return value, we have to do it, otherwise it'll
+        // call through to the real method. Likewise, for the result, just return a dummy object. We never look at it
+        // anyway.
+        ArgumentCaptor<AccessControlList> aclCaptor = ArgumentCaptor.forClass(AccessControlList.class);
+        doReturn(new AccessControlList()).when(synapseHelper).createAclWithRetry(aclCaptor.capture());
+
+        // execute and validate
+        String retVal = synapseHelper.createTableWithColumnsAndAcls(columnList, 1234, 5678,
+                "test-project", "My Table");
+        assertEquals(retVal, "test-table");
+
+        // validate tableCaptor
+        TableEntity table = tableCaptor.getValue();
+        assertEquals(table.getName(), "My Table");
+        assertEquals(table.getParentId(), "test-project");
+        assertEquals(table.getColumnIds(), ImmutableList.of("foo-col-id", "bar-col-id"));
+
+        // validate aclCaptor
+        AccessControlList acl = aclCaptor.getValue();
+        assertEquals(acl.getId(), "test-table");
+
+        Set<ResourceAccess> resourceAccessSet = acl.getResourceAccess();
+        assertEquals(resourceAccessSet.size(), 2);
+
+        ResourceAccess exporterOwnerAccess = new ResourceAccess();
+        exporterOwnerAccess.setPrincipalId(5678L);
+        exporterOwnerAccess.setAccessType(SynapseHelper.ACCESS_TYPE_ALL);
+        assertTrue(resourceAccessSet.contains(exporterOwnerAccess));
+
+        ResourceAccess dataAccessTeamAccess = new ResourceAccess();
+        dataAccessTeamAccess.setPrincipalId(1234L);
+        dataAccessTeamAccess.setAccessType(SynapseHelper.ACCESS_TYPE_READ);
+        assertTrue(resourceAccessSet.contains(dataAccessTeamAccess));
+    }
+
+    @Test
+    public void isCompatibleColumnTypeChanges() throws Exception {
+        ColumnModel intColumn = new ColumnModel();
+        intColumn.setName("my-column");
+        intColumn.setColumnType(ColumnType.INTEGER);
+
+        ColumnModel floatColumn = new ColumnModel();
+        floatColumn.setName("my-column");
+        floatColumn.setColumnType(ColumnType.DOUBLE);
+
+        assertTrue(SynapseHelper.isCompatibleColumn(intColumn, floatColumn));
+        assertFalse(SynapseHelper.isCompatibleColumn(floatColumn, intColumn));
+    }
+
+    @DataProvider
+    public Object[][] isCompatibleMaxLengthStringToStringDataProvider() {
+        // { oldMaxLength, newMaxLength, expected }
+        return new Object[][] {
+                { 10, 20, true },
+                { 20, 10, false },
+                { 15, 15, true },
+        };
+    }
+
+    @Test(dataProvider = "isCompatibleMaxLengthStringToStringDataProvider")
+    public void isCompatibleMaxLengthStringToString(long oldMaxLength, long newMaxLength, boolean expected)
+            throws Exception {
+        ColumnModel oldColumn = new ColumnModel();
+        oldColumn.setName("my-string");
+        oldColumn.setColumnType(ColumnType.STRING);
+        oldColumn.setMaximumSize(oldMaxLength);
+
+        ColumnModel newColumn = new ColumnModel();
+        newColumn.setName("my-string");
+        newColumn.setColumnType(ColumnType.STRING);
+        newColumn.setMaximumSize(newMaxLength);
+
+        assertEquals(SynapseHelper.isCompatibleColumn(oldColumn, newColumn), expected);
+    }
+
+    @DataProvider
+    public Object[][] isCompatibleMaxLengthWithNonStringsDataProvider() {
+        // { oldType, newType, newMaxLength, expected }
+        return new Object[][] {
+                { ColumnType.INTEGER, ColumnType.INTEGER, null, true },
+                { ColumnType.DOUBLE, ColumnType.STRING, 21L, false },
+                { ColumnType.DOUBLE, ColumnType.STRING, 23L, true },
+                { ColumnType.INTEGER, ColumnType.STRING, 19L, false },
+                { ColumnType.INTEGER, ColumnType.STRING, 21L, true },
+        };
+    }
+
+    @Test(dataProvider = "isCompatibleMaxLengthWithNonStringsDataProvider")
+    public void isCompatibleMaxLengthWithNonStrings(ColumnType oldType, ColumnType newType, Long newMaxLength,
+            boolean expected) throws Exception {
+        ColumnModel oldColumn = new ColumnModel();
+        oldColumn.setName("my-column");
+        oldColumn.setColumnType(oldType);
+        oldColumn.setMaximumSize(null);
+
+        ColumnModel newColumn = new ColumnModel();
+        newColumn.setName("my-column");
+        newColumn.setColumnType(newType);
+        newColumn.setMaximumSize(newMaxLength);
+
+        assertEquals(SynapseHelper.isCompatibleColumn(oldColumn, newColumn), expected);
+    }
+
+    // branch coverage
+    @Test(expectedExceptions = BridgeSynapseNonRetryableException.class, expectedExceptionsMessageRegExp =
+            "old column my-string has type STRING and no max length")
+    public void isCompatibleOldStringWithNoMaxLength() throws Exception {
+        ColumnModel oldColumn = new ColumnModel();
+        oldColumn.setName("my-string");
+        oldColumn.setColumnType(ColumnType.STRING);
+        oldColumn.setMaximumSize(null);
+
+        ColumnModel newColumn = new ColumnModel();
+        newColumn.setName("my-string");
+        newColumn.setColumnType(ColumnType.STRING);
+        newColumn.setMaximumSize(42L);
+
+        SynapseHelper.isCompatibleColumn(oldColumn, newColumn);
+    }
+
+    // branch coverage
+    @Test(expectedExceptions = BridgeSynapseNonRetryableException.class, expectedExceptionsMessageRegExp =
+            "new column my-string has type STRING and no max length")
+    public void isCompatibleNewStringWithNoMaxLength() throws Exception {
+        ColumnModel oldColumn = new ColumnModel();
+        oldColumn.setName("my-string");
+        oldColumn.setColumnType(ColumnType.STRING);
+        oldColumn.setMaximumSize(42L);
+
+        ColumnModel newColumn = new ColumnModel();
+        newColumn.setName("my-string");
+        newColumn.setColumnType(ColumnType.STRING);
+        newColumn.setMaximumSize(null);
+
+        SynapseHelper.isCompatibleColumn(oldColumn, newColumn);
+    }
+
+    @Test
+    public void isCompatibleColumnNameChange() throws Exception {
+        ColumnModel fooColumn = new ColumnModel();
+        fooColumn.setName("foo");
+        fooColumn.setColumnType(ColumnType.INTEGER);
+
+        ColumnModel barColumn = new ColumnModel();
+        barColumn.setName("bar");
+        barColumn.setColumnType(ColumnType.INTEGER);
+
+        assertFalse(SynapseHelper.isCompatibleColumn(fooColumn, barColumn));
+    }
+
+    // Most of these are retry wrappers, but we should test them anyway for branch coverage.
+
+    @Test
+    public void createAcl() throws Exception {
+        // mock Synapse Client - Unclear whether Synapse client just passes back the input ACL or if it creates a new
+        // one. Regardless, don't depend on this implementation. Just return a separate one for tests.
+        SynapseClient mockSynapseClient = mock(SynapseClient.class);
+        AccessControlList inputAcl = new AccessControlList();
+        AccessControlList outputAcl = new AccessControlList();
+        when(mockSynapseClient.createACL(inputAcl)).thenReturn(outputAcl);
+
+        SynapseHelper synapseHelper = new SynapseHelper();
+        synapseHelper.setSynapseClient(mockSynapseClient);
+
+        // execute and validate
+        AccessControlList retVal = synapseHelper.createAclWithRetry(inputAcl);
+        assertSame(retVal, outputAcl);
+    }
+
+    @Test
+    public void createColumnModels() throws Exception {
+        // mock Synapse Client - Similarly, return a new output list
+        SynapseClient mockSynapseClient = mock(SynapseClient.class);
+        List<ColumnModel> inputColumnModelList = ImmutableList.of(new ColumnModel());
+        List<ColumnModel> outputColumnModelList = ImmutableList.of(new ColumnModel());
+        when(mockSynapseClient.createColumnModels(inputColumnModelList)).thenReturn(outputColumnModelList);
+
+        SynapseHelper synapseHelper = new SynapseHelper();
+        synapseHelper.setSynapseClient(mockSynapseClient);
+
+        // execute and validate
+        List<ColumnModel> retVal = synapseHelper.createColumnModelsWithRetry(inputColumnModelList);
+        assertSame(retVal, outputColumnModelList);
+    }
+
+    @Test
+    public void createFileHandle() throws Exception {
+        // mock Synapse Client
+        SynapseClient mockSynapseClient = mock(SynapseClient.class);
+
+        File mockFile = mock(File.class);
+        S3FileHandle mockFileHandle = mock(S3FileHandle.class);
+        when(mockSynapseClient.multipartUpload(mockFile, null, null, null)).thenReturn(mockFileHandle);
+
+        SynapseHelper synapseHelper = new SynapseHelper();
+        synapseHelper.setSynapseClient(mockSynapseClient);
+
+        // execute and validate
+        FileHandle retVal = synapseHelper.createFileHandleWithRetry(mockFile);
+        assertSame(retVal, mockFileHandle);
+    }
+
+    @Test
+    public void createTable() throws Exception {
+        // mock Synapse Client - Similarly, return a new output table
+        SynapseClient mockSynapseClient = mock(SynapseClient.class);
+        TableEntity inputTable = new TableEntity();
+        TableEntity outputTable = new TableEntity();
+        when(mockSynapseClient.createEntity(inputTable)).thenReturn(outputTable);
+
+        SynapseHelper synapseHelper = new SynapseHelper();
+        synapseHelper.setSynapseClient(mockSynapseClient);
+
+        // execute and validate
+        TableEntity retVal = synapseHelper.createTableWithRetry(inputTable);
+        assertSame(retVal, outputTable);
+    }
+
+    @Test
+    public void getColumnModelsForTable() throws Exception {
+        // mock Synapse Client
+        SynapseClient mockSynapseClient = mock(SynapseClient.class);
+        List<ColumnModel> outputColumnModelList = ImmutableList.of(new ColumnModel());
+        when(mockSynapseClient.getColumnModelsForTableEntity("table-id")).thenReturn(outputColumnModelList);
+
+        SynapseHelper synapseHelper = new SynapseHelper();
+        synapseHelper.setSynapseClient(mockSynapseClient);
+
+        // execute and validate
+        List<ColumnModel> retVal = synapseHelper.getColumnModelsForTableWithRetry("table-id");
+        assertSame(retVal, outputColumnModelList);
+    }
+
+    @Test
+    public void getTable() throws Exception {
+        // mock Synapse Client
+        SynapseClient mockSynapseClient = mock(SynapseClient.class);
+        TableEntity tableEntity = new TableEntity();
+        when(mockSynapseClient.getEntity("table-id", TableEntity.class)).thenReturn(tableEntity);
+
+        SynapseHelper synapseHelper = new SynapseHelper();
+        synapseHelper.setSynapseClient(mockSynapseClient);
+
+        // execute and validate
+        TableEntity retVal = synapseHelper.getTableWithRetry("table-id");
+        assertSame(retVal, tableEntity);
+    }
+
+    @Test
+    public void startTableTransaction() throws Exception {
+        // mock Synapse Client
+        List<TableUpdateRequest> dummyChangeList = ImmutableList.of();
+        SynapseClient mockSynapseClient = mock(SynapseClient.class);
+        when(mockSynapseClient.startTableTransactionJob(same(dummyChangeList), eq("table-id"))).thenReturn(
+                "job-token");
+
+        SynapseHelper synapseHelper = new SynapseHelper();
+        synapseHelper.setSynapseClient(mockSynapseClient);
+
+        // execute and validate
+        String retVal = synapseHelper.startTableTransactionWithRetry(dummyChangeList, "table-id");
+        assertEquals(retVal, "job-token");
+    }
+
+    @Test
+    public void getTableTransactionResult() throws Exception {
+        // mock Synapse Client
+        List<TableUpdateResponse> dummyResponseList = ImmutableList.of();
+        SynapseClient mockSynapseClient = mock(SynapseClient.class);
+        when(mockSynapseClient.getTableTransactionJobResults("job-token", "table-id")).thenReturn(dummyResponseList);
+
+        SynapseHelper synapseHelper = new SynapseHelper();
+        synapseHelper.setSynapseClient(mockSynapseClient);
+
+        // execute and validate
+        List<TableUpdateResponse> retVal = synapseHelper.getTableTransactionResultWithRetry("job-token", "table-id");
+        assertSame(retVal, dummyResponseList);
+    }
+
+    @Test
+    public void getTableTransactionResultNotReady() throws Exception {
+        // mock Synapse Client
+        SynapseClient mockSynapseClient = mock(SynapseClient.class);
+        when(mockSynapseClient.getTableTransactionJobResults("job-token", "table-id")).thenThrow(
+                SynapseResultNotReadyException.class);
+
+        SynapseHelper synapseHelper = new SynapseHelper();
+        synapseHelper.setSynapseClient(mockSynapseClient);
+
+        // execute and validate
+        List<TableUpdateResponse> retVal = synapseHelper.getTableTransactionResultWithRetry("job-token", "table-id");
+        assertNull(retVal);
+    }
+
+    @Test
+    public void uploadTsvStart() throws Exception {
+        // mock Synapse Client
+        SynapseClient mockSynapseClient = mock(SynapseClient.class);
+        CsvTableDescriptor inputTableDesc = new CsvTableDescriptor();
+        when(mockSynapseClient.uploadCsvToTableAsyncStart("table-id", "file-handle-id", null, null, inputTableDesc,
+                null)).thenReturn("job-token");
+
+        SynapseHelper synapseHelper = new SynapseHelper();
+        synapseHelper.setSynapseClient(mockSynapseClient);
+
+        // execute and validate
+        String retVal = synapseHelper.uploadTsvStartWithRetry("table-id", "file-handle-id", inputTableDesc);
+        assertEquals(retVal, "job-token");
+    }
+
+    @Test
+    public void uploadTsvStatus() throws Exception {
+        // mock SynapseClient
+        SynapseClient mockSynapseClient = mock(SynapseClient.class);
+        UploadToTableResult result = new UploadToTableResult();
+        when(mockSynapseClient.uploadCsvToTableAsyncGet("job-token", "table-id")).thenReturn(result);
+
+        SynapseHelper synapseHelper = new SynapseHelper();
+        synapseHelper.setSynapseClient(mockSynapseClient);
+
+        // execute and validate
+        UploadToTableResult retVal = synapseHelper.getUploadTsvStatus("job-token", "table-id");
+        assertSame(retVal, result);
+    }
+
+    @Test
+    public void uploadTsvStatusNotReady() throws Exception {
+        // mock SynapseClient
+        SynapseClient mockSynapseClient = mock(SynapseClient.class);
+        when(mockSynapseClient.uploadCsvToTableAsyncGet("job-token", "table-id"))
+                .thenThrow(SynapseResultNotReadyException.class);
+
+        SynapseHelper synapseHelper = new SynapseHelper();
+        synapseHelper.setSynapseClient(mockSynapseClient);
+
+        // execute and validate
+        UploadToTableResult retVal = synapseHelper.getUploadTsvStatus("job-token", "table-id");
+        assertNull(retVal);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/synapse/SynapseHelperUpdateTableColumnsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/synapse/SynapseHelperUpdateTableColumnsTest.java
@@ -1,0 +1,161 @@
+package org.sagebionetworks.bridge.synapse;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.fail;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import org.mockito.ArgumentCaptor;
+import org.sagebionetworks.client.SynapseClient;
+import org.sagebionetworks.client.exceptions.SynapseResultNotReadyException;
+import org.sagebionetworks.repo.model.table.TableSchemaChangeRequest;
+import org.sagebionetworks.repo.model.table.TableSchemaChangeResponse;
+import org.sagebionetworks.repo.model.table.TableUpdateRequest;
+import org.sagebionetworks.repo.model.table.TableUpdateResponse;
+import org.sagebionetworks.repo.model.table.UploadToTableResult;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.exceptions.BridgeSynapseException;
+
+@SuppressWarnings({ "rawtypes", "unchecked" })
+public class SynapseHelperUpdateTableColumnsTest {
+    private static final TableSchemaChangeRequest DUMMY_REQUEST = new TableSchemaChangeRequest();
+    private static final String JOB_TOKEN = "job-token";
+    private static final String TABLE_ID = "table-id";
+
+    private ArgumentCaptor<List> changeListCaptor;
+    private SynapseClient mockSynapseClient;
+    private SynapseHelper synapseHelper;
+
+    @BeforeMethod
+    public void setup() throws Exception {
+        // mock Synapse Client and startTableTransactionJob
+        mockSynapseClient = mock(SynapseClient.class);
+
+        changeListCaptor = ArgumentCaptor.forClass(List.class);
+        when(mockSynapseClient.startTableTransactionJob(changeListCaptor.capture(), eq(TABLE_ID))).thenReturn(
+                JOB_TOKEN);
+
+        // create Synapse Helper
+        synapseHelper = new SynapseHelper();
+        synapseHelper.setSynapseClient(mockSynapseClient);
+
+        // Set async loop and rate limits to make tests more reasonable.
+        synapseHelper.setAsyncIntervalMillis(0);
+        synapseHelper.setAsyncTimeoutLoops(2);
+        synapseHelper.setRateLimit(1000);
+        synapseHelper.setGetColumnModelsRateLimit(1000);
+    }
+
+    @Test
+    public void immediateSuccess() throws Exception {
+        // mock SynapseClient.getTableTransationJobResults
+        TableSchemaChangeResponse singleResponse = new TableSchemaChangeResponse();
+        List<TableUpdateResponse> responseList = ImmutableList.of(singleResponse);
+        when(mockSynapseClient.getTableTransactionJobResults(JOB_TOKEN, TABLE_ID)).thenReturn(responseList);
+
+        // execute and validate
+        TableSchemaChangeResponse retVal = synapseHelper.updateTableColumns(DUMMY_REQUEST, TABLE_ID);
+        assertSame(retVal, singleResponse);
+        verify(mockSynapseClient, times(1)).getTableTransactionJobResults(any(), any());
+        validateInputList();
+    }
+
+    @Test
+    public void secondTry() throws Exception {
+        // mock SynapseClient.getTableTransationJobResults
+        TableSchemaChangeResponse singleResponse = new TableSchemaChangeResponse();
+        List<TableUpdateResponse> responseList = ImmutableList.of(singleResponse);
+        when(mockSynapseClient.getTableTransactionJobResults(JOB_TOKEN, TABLE_ID))
+                .thenThrow(SynapseResultNotReadyException.class).thenReturn(responseList);
+
+        // execute and validate
+        TableSchemaChangeResponse retVal = synapseHelper.updateTableColumns(DUMMY_REQUEST, TABLE_ID);
+        assertSame(retVal, singleResponse);
+        verify(mockSynapseClient, times(2)).getTableTransactionJobResults(any(), any());
+        validateInputList();
+    }
+
+    @Test
+    public void timeout() throws Exception {
+        // mock SynapseClient.getTableTransationJobResults
+        when(mockSynapseClient.getTableTransactionJobResults(JOB_TOKEN, TABLE_ID))
+                .thenThrow(SynapseResultNotReadyException.class);
+
+        // execute and validate
+        try {
+            synapseHelper.updateTableColumns(DUMMY_REQUEST, TABLE_ID);
+            fail("expected exception");
+        } catch (BridgeSynapseException ex) {
+            assertEquals(ex.getMessage(), "Timed out updating table columns for table " + TABLE_ID);
+        }
+        verify(mockSynapseClient, times(2)).getTableTransactionJobResults(any(), any());
+        validateInputList();
+    }
+
+    @Test
+    public void emptyResponseList() throws Exception {
+        // mock SynapseClient.getTableTransationJobResults
+        when(mockSynapseClient.getTableTransactionJobResults(JOB_TOKEN, TABLE_ID)).thenReturn(ImmutableList.of());
+
+        // execute and validate
+        try {
+            synapseHelper.updateTableColumns(DUMMY_REQUEST, TABLE_ID);
+            fail("expected exception");
+        } catch (BridgeSynapseException ex) {
+            assertEquals(ex.getMessage(), "Expected one table update response for table " + TABLE_ID +
+                    ", but got 0");
+        }
+        validateInputList();
+    }
+
+    @Test
+    public void multipleResponses() throws Exception {
+        // mock SynapseClient.getTableTransationJobResults
+        when(mockSynapseClient.getTableTransactionJobResults(JOB_TOKEN, TABLE_ID)).thenReturn(ImmutableList.of(
+                new TableSchemaChangeResponse(), new TableSchemaChangeResponse()));
+
+        // execute and validate
+        try {
+            synapseHelper.updateTableColumns(DUMMY_REQUEST, TABLE_ID);
+            fail("expected exception");
+        } catch (BridgeSynapseException ex) {
+            assertEquals(ex.getMessage(), "Expected one table update response for table " + TABLE_ID +
+                    ", but got 2");
+        }
+        validateInputList();
+    }
+
+    @Test
+    public void responseNotSchemaChange() throws Exception {
+        // mock SynapseClient.getTableTransationJobResults
+        when(mockSynapseClient.getTableTransactionJobResults(JOB_TOKEN, TABLE_ID)).thenReturn(ImmutableList.of(
+                new UploadToTableResult()));
+
+        // execute and validate
+        try {
+            synapseHelper.updateTableColumns(DUMMY_REQUEST, TABLE_ID);
+            fail("expected exception");
+        } catch (BridgeSynapseException ex) {
+            assertEquals(ex.getMessage(), "Expected a TableSchemaChangeResponse for table " + TABLE_ID +
+                    ", but got " + UploadToTableResult.class.getName());
+        }
+        validateInputList();
+    }
+
+    // This is done as a helper method instead of an After, so we can know which test failed.
+    private void validateInputList() {
+        List<TableUpdateRequest> changeList = changeListCaptor.getValue();
+        assertEquals(changeList.size(), 1);
+        assertSame(changeList.get(0), DUMMY_REQUEST);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/synapse/SynapseHelperUploadTsvToTableTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/synapse/SynapseHelperUploadTsvToTableTest.java
@@ -1,0 +1,106 @@
+package org.sagebionetworks.bridge.synapse;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.io.File;
+import java.util.List;
+
+import org.mockito.ArgumentCaptor;
+import org.sagebionetworks.client.SynapseClient;
+import org.sagebionetworks.client.exceptions.SynapseResultNotReadyException;
+import org.sagebionetworks.repo.model.file.FileHandle;
+import org.sagebionetworks.repo.model.table.CsvTableDescriptor;
+import org.sagebionetworks.repo.model.table.UploadToTableResult;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.exceptions.BridgeSynapseException;
+
+// Tests for SynapseHelper.uploadTsvFileToTable() and related methods.
+@SuppressWarnings("unchecked")
+public class SynapseHelperUploadTsvToTableTest {
+    private static final String TEST_FILE_HANDLE_ID = "file-handle-id";
+    private static final String TEST_JOB_TOKEN = "job-token";
+    private static final String TEST_TABLE_ID = "table-id";
+
+    private File mockTsvFile;
+    private SynapseClient mockSynapseClient;
+    private SynapseHelper synapseHelper;
+    private ArgumentCaptor<CsvTableDescriptor> tableDescCaptor;
+
+    @BeforeMethod
+    public void before() throws Exception {
+        // mock TSV
+        mockTsvFile = mock(File.class);
+
+        // mock Synapse Client - Mock everything except uploadCsvToTableAsyncGet(), which depends on the test.
+        mockSynapseClient = mock(SynapseClient.class);
+
+        tableDescCaptor = ArgumentCaptor.forClass(CsvTableDescriptor.class);
+        when(mockSynapseClient.uploadCsvToTableAsyncStart(eq(TEST_TABLE_ID), eq(TEST_FILE_HANDLE_ID),
+                isNull(String.class), isNull(Long.class), tableDescCaptor.capture(), isNull(List.class))).thenReturn(
+                TEST_JOB_TOKEN);
+
+        synapseHelper = spy(new SynapseHelper());
+        synapseHelper.setSynapseClient(mockSynapseClient);
+
+        // Set async loop and rate limits to make tests more reasonable.
+        synapseHelper.setAsyncIntervalMillis(0);
+        synapseHelper.setAsyncTimeoutLoops(2);
+        synapseHelper.setRateLimit(1000);
+        synapseHelper.setGetColumnModelsRateLimit(1000);
+
+        // Spy createFileHandle. This is tested somewhere else, and spying it here means we don't have to change tests
+        // in 3 different places when we change the createFileHandle implementation.
+        FileHandle mockFileHandle = mock(FileHandle.class);
+        when(mockFileHandle.getId()).thenReturn(TEST_FILE_HANDLE_ID);
+        doReturn(mockFileHandle).when(synapseHelper).createFileHandleWithRetry(mockTsvFile);
+    }
+
+    @Test
+    public void normalCase() throws Exception {
+        // mock synapseClient.uploadCsvToTableAsyncGet() - first loop not ready, second loop has results
+        UploadToTableResult uploadTsvStatus = new UploadToTableResult();
+        uploadTsvStatus.setRowsProcessed(42L);
+        when(mockSynapseClient.uploadCsvToTableAsyncGet(TEST_JOB_TOKEN, TEST_TABLE_ID)).thenThrow(
+                SynapseResultNotReadyException.class).thenReturn(uploadTsvStatus);
+
+        // execute and validate
+        long linesProcessed = synapseHelper.uploadTsvFileToTable(TEST_TABLE_ID, mockTsvFile);
+        assertEquals(linesProcessed, 42);
+
+        // validate CsvTableDescriptor
+        CsvTableDescriptor tableDesc = tableDescCaptor.getValue();
+        assertTrue(tableDesc.getIsFirstLineHeader());
+        assertEquals(tableDesc.getSeparator(), "\t");
+    }
+
+    @Test(expectedExceptions = BridgeSynapseException.class, expectedExceptionsMessageRegExp =
+            "Timed out uploading file handle " + TEST_FILE_HANDLE_ID)
+    public void timeout() throws Exception {
+        // mock synapseClient.uploadCsvToTableAsyncGet() to throw
+        when(mockSynapseClient.uploadCsvToTableAsyncGet(TEST_JOB_TOKEN, TEST_TABLE_ID)).thenThrow(
+                SynapseResultNotReadyException.class);
+
+        // execute
+        synapseHelper.uploadTsvFileToTable(TEST_TABLE_ID, mockTsvFile);
+    }
+
+    @Test(expectedExceptions = BridgeSynapseException.class, expectedExceptionsMessageRegExp = "Null rows processed")
+    public void nullGetRowsProcessed() throws Exception{
+        // mock synapseClient.uploadCsvToTableAsyncGet()
+        UploadToTableResult uploadTsvStatus = new UploadToTableResult();
+        uploadTsvStatus.setRowsProcessed(null);
+        when(mockSynapseClient.uploadCsvToTableAsyncGet(TEST_JOB_TOKEN, TEST_TABLE_ID)).thenReturn(uploadTsvStatus);
+
+        // execute
+        synapseHelper.uploadTsvFileToTable(TEST_TABLE_ID, mockTsvFile);
+    }
+}


### PR DESCRIPTION
These are needed to support the Bridge FitBit Worker.

Testing done:
* mvn verify (unit tests, findbugs, jacoco test coverage)
* manually tested as part of FitBit Worker development