### PR TITLE
BRIDGE-2037: improve CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 language: java
 jdk: oraclejdk8
 sudo: false
-script: mvn clean deploy
+cache:
+  directories:
+  - $HOME/.m2
+branches:
+  only:
+  - master
+  - /^stable-.*$/
+script: ./build.sh

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -ex
+if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then     # on pull requests
+    mvn clean verify
+elif [[ -z "$TRAVIS_TAG" && "$TRAVIS_BRANCH" == "master" ]]; then  # non-tag commits to master branch
+    mvn clean deploy
+elif [[ -z "$TRAVIS_TAG" && "$TRAVIS_BRANCH" =~ ^stable-.* ]]; then # non-tag commits to stable branches
+    mvn clean deploy
+fi
+exit $?
+

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>bridge-base</artifactId>
-    <version>2.7.8</version>
+    <version>2.7.8-SNAPSHOT</version>
 
     <properties>
         <aws.version>1.10.56</aws.version>


### PR DESCRIPTION
Setup travis CI to deploy SNAPSHOT builds from master branch and
deploy release builds from stable branches. Assumes that stable
branches are name "stable-*", for example "stable-2.7.8"[1]
This change will also allow travis to do pre-merge testing as opposed
to running tests post-merge.

[1] https://github.com/Sage-Bionetworks/bridge-base/tree/stable-2.7.8