### PR TITLE
SynapseHelper.safeUpdateTable() to merge old fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>bridge-base</artifactId>
-    <version>2.7.8</version>
+    <version>2.7.9</version>
 
     <properties>
         <aws.version>1.10.56</aws.version>


### PR DESCRIPTION
This is quality of life improvement for updating Synapse tables without deleting old columns. This change adds a flag to decide whether to merge unspecified fields with the requested list of fields, or to just error out the call.

Testing done:
* mvn verify (unit tests, Findbugs, Jacoco test coverage)
* tested as part of FitBitWorker