### PR TITLE
Refactor environment variable precedence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>bridge-base</artifactId>
-    <version>2.7.14</version>
+    <version>2.7.15</version>
 
     <properties>
         <aws.version>1.11.198</aws.version>

--- a/src/main/java/org/sagebionetworks/bridge/config/PropertiesConfig.java
+++ b/src/main/java/org/sagebionetworks/bridge/config/PropertiesConfig.java
@@ -234,13 +234,13 @@ public class PropertiesConfig implements Config {
     }
 
     private String read(final String key, final Properties properties) {
-        final String sysVal = sysReader.read(key);
-        if (sysVal != null) {
-            return sysVal;
-        }
         final String envVal = envReader.read(key);
         if (envVal != null) {
             return envVal;
+        }
+        final String sysVal = sysReader.read(key);
+        if (sysVal != null) {
+            return sysVal;
         }
         return properties.getProperty(key);
     }
@@ -270,9 +270,9 @@ public class PropertiesConfig implements Config {
         }
         // Overwrite with environment variables and system properties
         for (final String key : properties.stringPropertyNames()) {
-            String value = sysReader.read(key);
+            String value = envReader.read(key);
             if (value == null) {
-                value = envReader.read(key);
+                value = sysReader.read(key);
             }
             if (value != null) {
                 if (key.startsWith(envName + ".")) {


### PR DESCRIPTION
Allow OS environment variables to override system properties.
The use case is to be able to run the same build of bridge
application package in different AWS beanstalk environments.
Since Beanstalk sets OS environment variables those will
need to take precedence over system properties.