### PR TITLE
SynapseHelper.createTableWithColumnsAndAcls() to take a ID sets for permissions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>bridge-base</artifactId>
-    <version>2.7.19</version>
+    <version>2.7.20</version>
 
     <properties>
         <aws.version>1.11.198</aws.version>


### PR DESCRIPTION
Previously, we only took the "data access team" and "principal ID" for setting up table permissions. This change generalizes it so we can support adding the BridgeAdmin and BridgeStaff permissions to tables.