### PR TITLE
Update SynapseJavaClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>bridge-base</artifactId>
-    <version>2.7.20</version>
+    <version>2.7.21</version>
 
     <properties>
         <aws.version>1.11.198</aws.version>
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>synapseJavaClient</artifactId>
-            <version>206.0</version>
+            <version>268.02</version>
         </dependency>
         <dependency>
             <groupId>redis.clients</groupId>

--- a/src/main/java/org/sagebionetworks/bridge/synapse/SynapseHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/synapse/SynapseHelper.java
@@ -193,7 +193,7 @@ public class SynapseHelper {
         for (long adminPrincipalId : adminPrincipalIdSet) {
             ResourceAccess adminAccess = new ResourceAccess();
             adminAccess.setPrincipalId(adminPrincipalId);
-            adminAccess.setAccessType(ModelConstants.ENITY_ADMIN_ACCESS_PERMISSIONS);
+            adminAccess.setAccessType(ModelConstants.ENTITY_ADMIN_ACCESS_PERMISSIONS);
             resourceAccessSet.add(adminAccess);
         }
 

--- a/src/test/java/org/sagebionetworks/bridge/synapse/SynapseHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/synapse/SynapseHelperTest.java
@@ -102,9 +102,9 @@ public class SynapseHelperTest {
         assertEquals(resourceAccessByPrincipalId.get(1111L).getAccessType(), SynapseHelper.ACCESS_TYPE_READ);
         assertEquals(resourceAccessByPrincipalId.get(2222L).getAccessType(), SynapseHelper.ACCESS_TYPE_READ);
         assertEquals(resourceAccessByPrincipalId.get(3333L).getAccessType(),
-                ModelConstants.ENITY_ADMIN_ACCESS_PERMISSIONS);
+                ModelConstants.ENTITY_ADMIN_ACCESS_PERMISSIONS);
         assertEquals(resourceAccessByPrincipalId.get(4444L).getAccessType(),
-                ModelConstants.ENITY_ADMIN_ACCESS_PERMISSIONS);
+                ModelConstants.ENTITY_ADMIN_ACCESS_PERMISSIONS);
     }
 
     @Test


### PR DESCRIPTION
Need to update SynapseJavaClient, otherwise this causes conflicts in consuming packages. (As far as I can tell, this only affects BridgeWorkerPlatform.)