### PR TITLE
Fix streaming decryption

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>bridge-base</artifactId>
-    <version>2.7.21</version>
+    <version>2.7.22</version>
 
     <properties>
         <aws.version>1.11.198</aws.version>

--- a/src/main/java/org/sagebionetworks/bridge/crypto/BcCmsEncryptor.java
+++ b/src/main/java/org/sagebionetworks/bridge/crypto/BcCmsEncryptor.java
@@ -14,6 +14,7 @@ import com.google.common.io.ByteStreams;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cms.CMSEnvelopedData;
 import org.bouncycastle.cms.CMSEnvelopedDataGenerator;
+import org.bouncycastle.cms.CMSEnvelopedDataParser;
 import org.bouncycastle.cms.CMSException;
 import org.bouncycastle.cms.CMSProcessableByteArray;
 import org.bouncycastle.cms.CMSTypedData;
@@ -69,7 +70,7 @@ public final class BcCmsEncryptor implements CmsEncryptor {
     /** {@inheritDoc} */
     @Override
     public InputStream decrypt(InputStream encryptedStream) throws CertificateEncodingException, CMSException, IOException {
-        CMSEnvelopedData envelopedData = new CMSEnvelopedData(encryptedStream);
+        CMSEnvelopedDataParser envelopedData = new CMSEnvelopedDataParser(encryptedStream);
         X509CertificateHolder certHolder = new X509CertificateHolder(cert.getEncoded());
         RecipientId recipientId = new KeyTransRecipientId(certHolder.getIssuer(), certHolder.getSerialNumber());
         RecipientInformation recInfo = envelopedData.getRecipientInfos().get(recipientId);


### PR DESCRIPTION
See https://sagebionetworks.jira.com/browse/BRIDGE-2534

We descovered that CMSEnvelopedData(), even though it takes in an InputStream, actually ends up loading the entire file into memory, which is bad since some of these files are up to 100mb. Doing some research, it looks like CMSEnvelopedDataParser() properly streams the data. See:

* https://github.com/bcgit/bc-java/blob/master/pkix/src/main/java/org/bouncycastle/cms/CMSEnvelopedData.java
* https://github.com/bcgit/bc-java/blob/master/pkix/src/main/java/org/bouncycastle/cms/CMSProcessableByteArray.java
* https://github.com/bcgit/bc-java/blob/master/pkix/src/main/java/org/bouncycastle/cms/CMSEnvelopedDataParser.java
* https://github.com/bcgit/bc-java/blob/master/pkix/src/main/java/org/bouncycastle/cms/CMSProcessableInputStream.java

Note that this change can't be easily tested. I've tested that we can still encrypt and decrypt things just fine, but there's no easy way to verify that this does not load everything into memory.

Also note that neither CMSEnvelopedDataParser nor FileInputStream (returned by FileHelper) has any buffering. Convention is that the caller should add the buffer and close the streams. This will be added in a subsequent changelist in BridgeServer.