### PR TITLE
Updating Jackson library, and nomenclature from studyId -> appId

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>bridge-base</artifactId>
-    <version>2.7.24</version>
+    <version>2.7.25</version>
 
     <properties>
         <aws.version>1.11.198</aws.version>
         <bouncy.castle.version>1.52</bouncy.castle.version>
-        <jackson.version>2.9.8</jackson.version>
+        <jackson.version>2.11.0</jackson.version>
         <java.version>1.8</java.version>
         <logback.version>1.1.6</logback.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-core</artifactId>
-            <version>1.2.4</version>
+            <version>1.5.3</version>
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-core</artifactId>
-            <version>1.5.3</version>
+            <version>1.2.4</version>
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/src/main/java/org/sagebionetworks/bridge/crypto/AesGcmEncryptor.java
+++ b/src/main/java/org/sagebionetworks/bridge/crypto/AesGcmEncryptor.java
@@ -67,7 +67,7 @@ public class AesGcmEncryptor implements Encryptor {
         return cipher;
     }
 
-    private static final int KEY_BIT_SIZE = 128;
+    private static final int KEY_BIT_SIZE = 256;
     private final AesCipherService aesCipher;
     private final String key;
 }

--- a/src/main/java/org/sagebionetworks/bridge/crypto/AesGcmEncryptor.java
+++ b/src/main/java/org/sagebionetworks/bridge/crypto/AesGcmEncryptor.java
@@ -67,7 +67,7 @@ public class AesGcmEncryptor implements Encryptor {
         return cipher;
     }
 
-    private static final int KEY_BIT_SIZE = 256;
+    private static final int KEY_BIT_SIZE = 128;
     private final AesCipherService aesCipher;
     private final String key;
 }

--- a/src/main/java/org/sagebionetworks/bridge/schema/UploadSchema.java
+++ b/src/main/java/org/sagebionetworks/bridge/schema/UploadSchema.java
@@ -55,10 +55,10 @@ public class UploadSchema {
             throw new IllegalArgumentException("Malformed key " + ddbKey);
         }
 
-        String studyId = ddbKeyTokenArray[0];
+        String appId = ddbKeyTokenArray[0];
         String schemaId = ddbKeyTokenArray[1];
         int rev = ddbItem.getInt("revision");
-        UploadSchemaKey key = new UploadSchemaKey.Builder().withStudyId(studyId).withSchemaId(schemaId)
+        UploadSchemaKey key = new UploadSchemaKey.Builder().withAppId(appId).withSchemaId(schemaId)
                 .withRevision(rev).build();
         schemaBuilder.withKey(key);
 
@@ -73,7 +73,7 @@ public class UploadSchema {
         return schemaBuilder.build();
     }
 
-    /** Schema key (study, schema, revision). */
+    /** Schema key (appId, schema, revision). */
     public UploadSchemaKey getKey() {
         return key;
     }

--- a/src/main/java/org/sagebionetworks/bridge/schema/UploadSchemaKey.java
+++ b/src/main/java/org/sagebionetworks/bridge/schema/UploadSchemaKey.java
@@ -4,23 +4,23 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Objects;
 import org.apache.commons.lang3.StringUtils;
 
-/** This class represents an upload schema key, with a study ID, schema ID, and revision. */
+/** This class represents an upload schema key, with a app ID, schema ID, and revision. */
 @JsonDeserialize(builder = UploadSchemaKey.Builder.class)
 public final class UploadSchemaKey {
-    private final String studyId;
+    private final String appId;
     private final String schemaId;
     private final int revision;
 
     /** Private constructor. To construct, use Builder. */
-    private UploadSchemaKey(String studyId, String schemaId, int revision) {
-        this.studyId = studyId;
+    private UploadSchemaKey(String appId, String schemaId, int revision) {
+        this.appId = appId;
         this.schemaId = schemaId;
         this.revision = revision;
     }
 
-    /** ID of the study this schema lives in. */
-    public String getStudyId() {
-        return studyId;
+    /** ID of the app this schema lives in. */
+    public String getAppId() {
+        return appId;
     }
 
     /** ID of the schema. */
@@ -44,34 +44,34 @@ public final class UploadSchemaKey {
         }
         UploadSchemaKey schemaKey = (UploadSchemaKey) o;
         return Objects.equal(revision, schemaKey.revision) &&
-                Objects.equal(studyId, schemaKey.studyId) &&
+                Objects.equal(appId, schemaKey.appId) &&
                 Objects.equal(schemaId, schemaKey.schemaId);
     }
 
     /** {@inheritDoc} */
     @Override
     public int hashCode() {
-        return Objects.hashCode(studyId, schemaId, revision);
+        return Objects.hashCode(appId, schemaId, revision);
     }
 
     /**
-     * Returns the string representation of the schema, which is "[studyId]-[schemaId]-v[revision]". For example:
+     * Returns the string representation of the schema, which is "[appId]-[schemaId]-v[revision]". For example:
      * parkinson-Voice Activity-v1
      */
     @Override
     public String toString() {
-        return studyId + "-" + schemaId + "-v" + revision;
+        return appId + "-" + schemaId + "-v" + revision;
     }
 
     /** Builder for an UploadSchemaKey. */
     public static class Builder {
-        private String studyId;
+        private String appId;
         private String schemaId;
         private Integer revision;
 
-        /** @see UploadSchemaKey#getStudyId */
-        public Builder withStudyId(String studyId) {
-            this.studyId = studyId;
+        /** @see UploadSchemaKey#getAppId */
+        public Builder withAppId(String appId) {
+            this.appId = appId;
             return this;
         }
 
@@ -89,8 +89,8 @@ public final class UploadSchemaKey {
 
         /** Builds an UploadSchemaKey and validate that all fields are specified and that revision is positive. */
         public UploadSchemaKey build() {
-            if (StringUtils.isBlank(studyId)) {
-                throw new IllegalStateException("studyId must be specified");
+            if (StringUtils.isBlank(appId)) {
+                throw new IllegalStateException("appId must be specified");
             }
 
             if (StringUtils.isBlank(schemaId)) {
@@ -103,7 +103,7 @@ public final class UploadSchemaKey {
                 throw new IllegalStateException("revision must be specified and positive");
             }
 
-            return new UploadSchemaKey(studyId, schemaId, revision);
+            return new UploadSchemaKey(appId, schemaId, revision);
         }
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/schema/UploadSchemaKey.java
+++ b/src/main/java/org/sagebionetworks/bridge/schema/UploadSchemaKey.java
@@ -22,7 +22,7 @@ public final class UploadSchemaKey {
     public String getAppId() {
         return appId;
     }
-
+    
     /** ID of the schema. */
     public String getSchemaId() {
         return schemaId;
@@ -72,6 +72,11 @@ public final class UploadSchemaKey {
         /** @see UploadSchemaKey#getAppId */
         public Builder withAppId(String appId) {
             this.appId = appId;
+            return this;
+        }
+        
+        public Builder withStudyId(String studyId) {
+            this.appId = studyId;
             return this;
         }
 

--- a/src/main/java/org/sagebionetworks/bridge/schema/UploadSchemaKey.java
+++ b/src/main/java/org/sagebionetworks/bridge/schema/UploadSchemaKey.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.schema;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Objects;
 import org.apache.commons.lang3.StringUtils;
@@ -70,16 +71,12 @@ public final class UploadSchemaKey {
         private Integer revision;
 
         /** @see UploadSchemaKey#getAppId */
+        @JsonAlias("studyId")
         public Builder withAppId(String appId) {
             this.appId = appId;
             return this;
         }
         
-        public Builder withStudyId(String studyId) {
-            this.appId = studyId;
-            return this;
-        }
-
         /** @see UploadSchemaKey#getSchemaId */
         public Builder withSchemaId(String schemaId) {
             this.schemaId = schemaId;

--- a/src/test/java/org/sagebionetworks/bridge/schema/UploadSchemaKeyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/schema/UploadSchemaKeyTest.java
@@ -16,7 +16,7 @@ public class UploadSchemaKeyTest {
 
     @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*appId.*")
     public void nullAppId() {
-        new UploadSchemaKey.Builder().withSchemaId("test-schema").withRevision(42).build();
+        new UploadSchemaKey.Builder().withAppId(null).withSchemaId("test-schema").withRevision(42).build();
     }
 
     @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*appId.*")
@@ -70,7 +70,27 @@ public class UploadSchemaKeyTest {
     }
 
     @Test
-    public void jsonSerialize() throws Exception {
+    public void jsonSerializeWithStudyId() throws Exception {
+        // start with JSON
+        String jsonText = "{\n" +
+                "   \"studyId\":\"test-app\",\n" +
+                "   \"schemaId\":\"test-schema\",\n" +
+                "   \"revision\":42\n" +
+                "}";
+
+        // convert to POJO
+        UploadSchemaKey schemaKey = DefaultObjectMapper.INSTANCE.readValue(jsonText, UploadSchemaKey.class);
+        assertEquals(schemaKey.toString(), "test-app-test-schema-v42");
+
+        // convert back to JSON
+        JsonNode jsonNode = DefaultObjectMapper.INSTANCE.convertValue(schemaKey, JsonNode.class);
+        assertEquals(jsonNode.get("appId").textValue(), "test-app");
+        assertEquals(jsonNode.get("schemaId").textValue(), "test-schema");
+        assertEquals(jsonNode.get("revision").intValue(), 42);
+    }
+    
+    @Test
+    public void jsonSerializeWithAppId() throws Exception {
         // start with JSON
         String jsonText = "{\n" +
                 "   \"appId\":\"test-app\",\n" +

--- a/src/test/java/org/sagebionetworks/bridge/schema/UploadSchemaKeyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/schema/UploadSchemaKeyTest.java
@@ -14,77 +14,77 @@ public class UploadSchemaKeyTest {
         EqualsVerifier.forClass(UploadSchemaKey.class).allFieldsShouldBeUsed().verify();
     }
 
-    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*studyId.*")
-    public void nullStudyId() {
+    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*appId.*")
+    public void nullAppId() {
         new UploadSchemaKey.Builder().withSchemaId("test-schema").withRevision(42).build();
     }
 
-    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*studyId.*")
-    public void emptyStudyId() {
-        new UploadSchemaKey.Builder().withStudyId("").withSchemaId("test-schema").withRevision(42).build();
+    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*appId.*")
+    public void emptyAppId() {
+        new UploadSchemaKey.Builder().withAppId("").withSchemaId("test-schema").withRevision(42).build();
     }
 
-    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*studyId.*")
-    public void blankStudyId() {
-        new UploadSchemaKey.Builder().withStudyId("   ").withSchemaId("test-schema").withRevision(42).build();
+    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*appId.*")
+    public void blankAppId() {
+        new UploadSchemaKey.Builder().withAppId("   ").withSchemaId("test-schema").withRevision(42).build();
     }
 
     @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*schemaId.*")
     public void nullSchemaId() {
-        new UploadSchemaKey.Builder().withStudyId("test-study").withRevision(42).build();
+        new UploadSchemaKey.Builder().withAppId("test-app").withRevision(42).build();
     }
 
     @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*schemaId.*")
     public void emptySchemaId() {
-        new UploadSchemaKey.Builder().withStudyId("test-study").withSchemaId("").withRevision(42).build();
+        new UploadSchemaKey.Builder().withAppId("test-app").withSchemaId("").withRevision(42).build();
     }
 
     @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*schemaId.*")
     public void blankSchemaId() {
-        new UploadSchemaKey.Builder().withStudyId("test-study").withSchemaId("   ").withRevision(42).build();
+        new UploadSchemaKey.Builder().withAppId("test-app").withSchemaId("   ").withRevision(42).build();
     }
 
     @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*revision.*")
     public void noRev() {
-        new UploadSchemaKey.Builder().withStudyId("test-study").withSchemaId("test-schema").build();
+        new UploadSchemaKey.Builder().withAppId("test-app").withSchemaId("test-schema").build();
     }
 
     @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*revision.*")
     public void negativeRev() {
-        new UploadSchemaKey.Builder().withStudyId("test-study").withSchemaId("test-schema").withRevision(-1).build();
+        new UploadSchemaKey.Builder().withAppId("test-app").withSchemaId("test-schema").withRevision(-1).build();
     }
 
     @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*revision.*")
     public void zeroRev() {
-        new UploadSchemaKey.Builder().withStudyId("test-study").withSchemaId("test-schema").withRevision(0).build();
+        new UploadSchemaKey.Builder().withAppId("test-app").withSchemaId("test-schema").withRevision(0).build();
     }
 
     @Test
     public void happyCase() {
-        UploadSchemaKey schemaKey = new UploadSchemaKey.Builder().withStudyId("test-study").withSchemaId("test-schema")
+        UploadSchemaKey schemaKey = new UploadSchemaKey.Builder().withAppId("test-app").withSchemaId("test-schema")
                 .withRevision(42).build();
-        assertEquals(schemaKey.getStudyId(), "test-study");
+        assertEquals(schemaKey.getAppId(), "test-app");
         assertEquals(schemaKey.getSchemaId(), "test-schema");
         assertEquals(schemaKey.getRevision(), 42);
-        assertEquals(schemaKey.toString(), "test-study-test-schema-v42");
+        assertEquals(schemaKey.toString(), "test-app-test-schema-v42");
     }
 
     @Test
     public void jsonSerialize() throws Exception {
         // start with JSON
         String jsonText = "{\n" +
-                "   \"studyId\":\"test-study\",\n" +
+                "   \"appId\":\"test-app\",\n" +
                 "   \"schemaId\":\"test-schema\",\n" +
                 "   \"revision\":42\n" +
                 "}";
 
         // convert to POJO
         UploadSchemaKey schemaKey = DefaultObjectMapper.INSTANCE.readValue(jsonText, UploadSchemaKey.class);
-        assertEquals(schemaKey.toString(), "test-study-test-schema-v42");
+        assertEquals(schemaKey.toString(), "test-app-test-schema-v42");
 
         // convert back to JSON
         JsonNode jsonNode = DefaultObjectMapper.INSTANCE.convertValue(schemaKey, JsonNode.class);
-        assertEquals(jsonNode.get("studyId").textValue(), "test-study");
+        assertEquals(jsonNode.get("appId").textValue(), "test-app");
         assertEquals(jsonNode.get("schemaId").textValue(), "test-schema");
         assertEquals(jsonNode.get("revision").intValue(), 42);
     }

--- a/src/test/java/org/sagebionetworks/bridge/schema/UploadSchemaTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/schema/UploadSchemaTest.java
@@ -22,11 +22,11 @@ public class UploadSchemaTest {
 
     @Test
     public void happyCase() {
-        UploadSchemaKey schemaKey = new UploadSchemaKey.Builder().withStudyId("test-study").withSchemaId("test-schema")
+        UploadSchemaKey schemaKey = new UploadSchemaKey.Builder().withAppId("test-app").withSchemaId("test-schema")
                 .withRevision(7).build();
         UploadSchema schema = new UploadSchema.Builder().withKey(schemaKey).addField("foo", "STRING")
                 .addField("bar", "INT").build();
-        assertEquals(schema.getKey().toString(), "test-study-test-schema-v7");
+        assertEquals(schema.getKey().toString(), "test-app-test-schema-v7");
 
         List<String> fieldNameList = schema.getFieldNameList();
         assertEquals(fieldNameList.size(), 2);
@@ -46,17 +46,18 @@ public class UploadSchemaTest {
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void emptyFieldDefList() {
-        UploadSchemaKey schemaKey = new UploadSchemaKey.Builder().withStudyId("test-study").withSchemaId("test-schema")
+        UploadSchemaKey schemaKey = new UploadSchemaKey.Builder().withAppId("test-app").withSchemaId("test-schema")
                 .withRevision(7).build();
         new UploadSchema.Builder().withKey(schemaKey).build();
     }
 
     @Test
     public void fromDdbItem() throws Exception {
-        Item ddbItem = new Item().withString("studyId", "test-study").withString("key", "test-study:ddb-schema")
+        // In DynamoDB, appId is named "studyId" for legacy reasons.
+        Item ddbItem = new Item().withString("studyId", "test-app").withString("key", "test-app:ddb-schema")
                 .withInt("revision", 13).withString("fieldDefinitions", DUMMY_FIELD_DEF_LIST_JSON);
         UploadSchema schema = UploadSchema.fromDdbItem(ddbItem);
-        assertEquals(schema.getKey().toString(), "test-study-ddb-schema-v13");
+        assertEquals(schema.getKey().toString(), "test-app-ddb-schema-v13");
 
         List<String> fieldNameList = schema.getFieldNameList();
         assertEquals(fieldNameList.size(), 2);
@@ -71,7 +72,8 @@ public class UploadSchemaTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void fromDdbItemMalformedKey() throws Exception {
-        Item ddbItem = new Item().withString("studyId", "test-study").withString("key", "required colon missing")
+        // In DynamoDB, appId is named "studyId" for legacy reasons.
+        Item ddbItem = new Item().withString("studyId", "test-app").withString("key", "required colon missing")
                 .withInt("revision", 2).withString("fieldDefinitions", DUMMY_FIELD_DEF_LIST_JSON);
         UploadSchema.fromDdbItem(ddbItem);
     }
@@ -79,10 +81,11 @@ public class UploadSchemaTest {
 
     @Test
     public void fromDdbItemSchemaIdWithColon() throws Exception {
-        Item ddbItem = new Item().withString("studyId", "test-study").withString("key", "test-study:has:colons")
+        // In DynamoDB, appId is named "studyId" for legacy reasons.
+        Item ddbItem = new Item().withString("studyId", "test-app").withString("key", "test-app:has:colons")
                 .withInt("revision", 42).withString("fieldDefinitions", DUMMY_FIELD_DEF_LIST_JSON);
         UploadSchema schema = UploadSchema.fromDdbItem(ddbItem);
-        assertEquals(schema.getKey().toString(), "test-study-has:colons-v42");
+        assertEquals(schema.getKey().toString(), "test-app-has:colons-v42");
 
         // Don't bother testing the actual fields. They've already been tested in a previous test case.
     }


### PR DESCRIPTION
Where Item is being used, I believe it's a representation of the DynamoDB table where the attribute is still studyId, so I left that while renaming everything else. If you could verify this... there's also the question as to whether any object in base is created from a deserialization of JSON which might not contain appId at this point.