### PR TITLE
Add PollSqsWorkerRetryableException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>bridge-base</artifactId>
-    <version>2.8.0</version>
+    <version>2.8.1</version>
 
     <properties>
         <aws.version>1.11.851</aws.version>

--- a/src/main/java/org/sagebionetworks/bridge/sqs/PollSqsWorkerRetryableException.java
+++ b/src/main/java/org/sagebionetworks/bridge/sqs/PollSqsWorkerRetryableException.java
@@ -1,0 +1,24 @@
+package org.sagebionetworks.bridge.sqs;
+
+/**
+ * PollSqsWorker retries on all exception other than PollSqsWorkerBadRequestException. However, some exceptions (such
+ * as Synapse not being writable for weekly maintenance) are run-of-the-mill and expected. We still want to retry, but
+ * we don't want to log an error. In those cases, you should use this exception.
+ */
+@SuppressWarnings("serial")
+public class PollSqsWorkerRetryableException extends Exception {
+    public PollSqsWorkerRetryableException() {
+    }
+
+    public PollSqsWorkerRetryableException(String message) {
+        super(message);
+    }
+
+    public PollSqsWorkerRetryableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public PollSqsWorkerRetryableException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
Sometimes, we have an exception where we want the SQS message to be re-vended, but we don't want to log an error. For example, Synapse being non-writable. This adds a new exception type that logs a warning instead.

This is needed for https://github.com/Sage-Bionetworks/BridgeWorkerPlatform/pull/135