### PR TITLE
BRIDGE-3210 add null check to BcCmsEncryptor.decrypt()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>bridge-base</artifactId>
-    <version>2.8.2</version>
+    <version>2.8.3</version>
 
     <properties>
         <aws.version>1.11.851</aws.version>
@@ -205,6 +205,7 @@
                         <!-- no point in testing exceptions, since they are entirely boilerplate code -->
                         <exclude>org/sagebionetworks/bridge/exceptions/*</exclude>
                         <exclude>org/sagebionetworks/bridge/config/*Exception.class</exclude>
+                        <exclude>org/sagebionetworks/bridge/crypto/*Exception.class</exclude>
                         <exclude>org/sagebionetworks/bridge/dynamodb/*Exception.class</exclude>
                         <exclude>org/sagebionetworks/bridge/lock/*Exception.class</exclude>
                         <exclude>org/sagebionetworks/bridge/redis/*Exception.class</exclude>

--- a/src/main/java/org/sagebionetworks/bridge/crypto/CmsEncryptor.java
+++ b/src/main/java/org/sagebionetworks/bridge/crypto/CmsEncryptor.java
@@ -13,11 +13,13 @@ public interface CmsEncryptor {
 
     byte[] encrypt(byte[] bytes) throws CMSException, IOException;
 
-    byte[] decrypt(byte[] bytes) throws CMSException, CertificateEncodingException, IOException;
+    byte[] decrypt(byte[] bytes) throws CMSException, CertificateEncodingException, IOException,
+            WrongEncryptionKeyException;
 
     /**
      * Takes in a stream of encrypted data and outputs a stream of decrypted data. The caller is responsible for
      * closing both streams.
      */
-    InputStream decrypt(InputStream encryptedStream) throws CertificateEncodingException, CMSException, IOException;
+    InputStream decrypt(InputStream encryptedStream) throws CertificateEncodingException, CMSException, IOException,
+            WrongEncryptionKeyException;
 }

--- a/src/main/java/org/sagebionetworks/bridge/crypto/WrongEncryptionKeyException.java
+++ b/src/main/java/org/sagebionetworks/bridge/crypto/WrongEncryptionKeyException.java
@@ -1,0 +1,20 @@
+package org.sagebionetworks.bridge.crypto;
+
+/** Thrown if someone tries to decrypt data with the wrong key. */
+@SuppressWarnings("serial")
+public class WrongEncryptionKeyException extends Exception {
+    public WrongEncryptionKeyException() {
+    }
+
+    public WrongEncryptionKeyException(String message) {
+        super(message);
+    }
+
+    public WrongEncryptionKeyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public WrongEncryptionKeyException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/crypto/BcCmsEncryptorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/crypto/BcCmsEncryptorTest.java
@@ -82,4 +82,21 @@ public class BcCmsEncryptorTest {
             // expected exception
         }
     }
+
+    @Test(expectedExceptions = WrongEncryptionKeyException.class)
+    public void decryptWithWrongKey() throws Exception {
+        // Make an encryptor with the wrong key.
+        KeyPair keyPair = KeyPairFactory.newRsa2048();
+        CertificateFactory certFactory = new BcCertificateFactory();
+        X509Certificate cert = certFactory.newCertificate(keyPair, new CertificateInfo.Builder().build());
+        CmsEncryptor wrongKeyEncryptor = new BcCmsEncryptor(cert, null);
+
+        // Encrypt some data with the wrong key.
+        String text = "some text";
+        byte[] bytes = text.getBytes(StandardCharsets.ISO_8859_1);
+        byte[] encrypted = wrongKeyEncryptor.encrypt(bytes);
+
+        // Decrypt with the correct key. This will throw.
+        encryptorTwoWay.decrypt(encrypted);
+    }
 }


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-3210

This error can happen if someone encrypts an upload with the wrong encryption key, and then we try to decrypt it. Instead of throwing a cryptic NullPointerException, we now throw a more helpful WrongEncryptionKeyException.