### PR TITLE
Deployable jar (BRIDGE-3308)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>bridge-base</artifactId>
-    <version>2.8.4</version>
+    <version>2.8.5</version>
 
     <properties>
         <aws.version>1.11.851</aws.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>bridge-base</artifactId>
-    <version>2.8.3</version>
+    <version>2.8.4</version>
 
     <properties>
         <aws.version>1.11.851</aws.version>

--- a/src/main/java/org/sagebionetworks/bridge/config/PropertiesConfig.java
+++ b/src/main/java/org/sagebionetworks/bridge/config/PropertiesConfig.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.config;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -151,8 +152,19 @@ public class PropertiesConfig implements Config {
 
     private static Properties setupPropertiesFromPath (final Path configTemplate) throws IOException {
         final Properties properties = new Properties();
-        try (final Reader templateReader = Files.newBufferedReader(configTemplate, StandardCharsets.UTF_8)) {
-            properties.load(templateReader);
+        String path = configTemplate.toString();
+        // For executable jar files, Spring Boot creates a jar with embedded jar files that is not
+        // a standard format, and its URIs seem to reference a propriety FileSystem implementation.
+        // However, we can apparently sidestep this with some parsing of the URI.
+        if (path.contains("BOOT-INF")) {
+            path = path.substring(path.indexOf("/BOOT-INF")).replaceAll("!", "");
+            try (final InputStream in = PropertiesConfig.class.getResourceAsStream(path)) {
+                properties.load(in);
+            }
+        } else {
+            try (Reader templateReader = Files.newBufferedReader(configTemplate, StandardCharsets.UTF_8)) {
+                properties.load(templateReader);
+            }            
         }
         return properties;
     }

--- a/src/test/java/org/sagebionetworks/bridge/config/PropertiesConfigTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/config/PropertiesConfigTest.java
@@ -5,7 +5,6 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;


### PR DESCRIPTION
Our configuration system reads from custom property files that are bundled into the assembled JAR, so we need some code changes to extract and load those resources (rather than from filesystem).