### PR TITLE
add exponential backoff to SynapseHelper async poll loops

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>bridge-base</artifactId>
-    <version>2.8.5</version>
+    <version>2.8.6</version>
 
     <properties>
         <aws.version>1.11.851</aws.version>

--- a/src/test/java/org/sagebionetworks/bridge/synapse/SynapseHelperAppendRowsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/synapse/SynapseHelperAppendRowsTest.java
@@ -36,8 +36,7 @@ public class SynapseHelperAppendRowsTest {
         MockitoAnnotations.initMocks(this);
 
         // Set async loop and rate limits to make tests more reasonable.
-        synapseHelper.setAsyncIntervalMillis(0);
-        synapseHelper.setAsyncTimeoutLoops(2);
+        synapseHelper.setAsyncGetBackoffPlan(new int[] { 0, 0 });
         synapseHelper.setRateLimit(1000);
         synapseHelper.setGetColumnModelsRateLimit(1000);
 

--- a/src/test/java/org/sagebionetworks/bridge/synapse/SynapseHelperUpdateTableColumnsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/synapse/SynapseHelperUpdateTableColumnsTest.java
@@ -50,8 +50,7 @@ public class SynapseHelperUpdateTableColumnsTest {
         synapseHelper.setSynapseClient(mockSynapseClient);
 
         // Set async loop and rate limits to make tests more reasonable.
-        synapseHelper.setAsyncIntervalMillis(0);
-        synapseHelper.setAsyncTimeoutLoops(2);
+        synapseHelper.setAsyncGetBackoffPlan(new int[] { 0, 0 });
         synapseHelper.setRateLimit(1000);
         synapseHelper.setGetColumnModelsRateLimit(1000);
     }

--- a/src/test/java/org/sagebionetworks/bridge/synapse/SynapseHelperUploadTsvToTableTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/synapse/SynapseHelperUploadTsvToTableTest.java
@@ -52,8 +52,7 @@ public class SynapseHelperUploadTsvToTableTest {
         synapseHelper.setSynapseClient(mockSynapseClient);
 
         // Set async loop and rate limits to make tests more reasonable.
-        synapseHelper.setAsyncIntervalMillis(0);
-        synapseHelper.setAsyncTimeoutLoops(2);
+        synapseHelper.setAsyncGetBackoffPlan(new int[] { 0, 0 });
         synapseHelper.setRateLimit(1000);
         synapseHelper.setGetColumnModelsRateLimit(1000);
 


### PR DESCRIPTION
Worker append rows to table call frequently hits the max wait time in our polling loops. Our current polling strategy is to wait 1 second before each poll for 5 minutes. This means that we call Synapse up to 300 times for each job to append rows to tables. Given how often we hit the max wait time, this means we are sending a lot of traffic to Synapse.

This pull request changes to a more sensible exponential backoff strategy, starting at 1 second and capping out at 60 seconds and trying a total of 10 times. This means the max wait time is still around 5 minutes, but now we're making only 10 calls instead of 300. This will hopefully resolve our issues with Synapse.